### PR TITLE
feat: add keybind-triggered inventory sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,5 +118,6 @@ runs/
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
+.claude/*.local.*
 CLAUDE.local.md
 AGENTS.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+NeoForge mod for Minecraft 1.21.1 ("Better Inventory Sorter"). Java 21, Gradle 8.8, NeoForge ModDev plugin v2.0.140. Parchment mappings for human-readable Minecraft names.
+
+## Build and Run Commands
+
+All commands use the Windows Gradle wrapper:
+
+- **Build:** `.\gradlew.bat build`
+- **Run client:** `.\gradlew.bat runClient`
+- **Run server:** `.\gradlew.bat runServer`
+- **Run game tests:** `.\gradlew.bat runGameTestServer`
+- **Data generation:** `.\gradlew.bat runData`
+
+Game tests use the NeoForge GameTest framework (not JUnit). Tests are filtered by the mod namespace `betterinventorysorter`. The `runGameTestServer` task will crash if no game tests are registered.
+
+## Architecture
+
+- **Mod entrypoint:** `src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java` — annotated with `@Mod("betterinventorysorter")`. Registers blocks, items, and creative tabs via NeoForge Deferred Registers.
+- **Configuration:** `src/main/java/xyz/bannach/betterinventorysorter/Config.java` — uses `ModConfigSpec` and `@EventBusSubscriber` for config loading.
+- **Mod metadata template:** `src/main/templates/META-INF/neoforge.mods.toml` — property placeholders are expanded from `gradle.properties` by the `generateModMetadata` task. Edit this template (not the generated output in `build/`).
+- **Assets:** `src/main/resources/assets/betterinventorysorter/` (lang files, textures, models, etc.)
+- **Generated resources:** `src/generated/resources/` — output from `runData`. Do not edit by hand.
+
+## Key Conventions
+
+- The mod ID `betterinventorysorter` must stay aligned across `gradle.properties` (`mod_id`), the `@Mod` annotation, and `neoforge.mods.toml`.
+- Register new items/blocks via Deferred Registers in the main mod class or dedicated registry classes.
+- Mod version and dependency ranges are defined in `gradle.properties` and templated into `neoforge.mods.toml` at build time — change them in `gradle.properties`, not the template.
+- Generated resources (`src/generated/resources/`) should not be hand-edited; update data providers and re-run `.\gradlew.bat runData`.
+
+## Git and PR Conventions
+
+- **Commits:** Use [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add sort keybinding`, `fix: prevent crash on empty inventory`, `chore: update dependencies`).
+- **PR titles:** Must also use conventional commit format (e.g., `feat: add keybind-triggered inventory sorting`).
+- **PR descriptions:** Include a brief description of the changes, a summary of what was changed, and any testing steps that may need to be taken.

--- a/src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java
@@ -1,120 +1,22 @@
 package xyz.bannach.betterinventorysorter;
 
 import com.mojang.logging.LogUtils;
-import net.minecraft.client.Minecraft;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.food.FoodProperties;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.material.MapColor;
-import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
-import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
-import net.neoforged.fml.config.ModConfig;
-import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
-import net.neoforged.neoforge.event.server.ServerStartingEvent;
-import net.neoforged.neoforge.registries.DeferredBlock;
-import net.neoforged.neoforge.registries.DeferredHolder;
-import net.neoforged.neoforge.registries.DeferredItem;
-import net.neoforged.neoforge.registries.DeferredRegister;
 import org.slf4j.Logger;
 
-// The value here should match an entry in the META-INF/neoforge.mods.toml file
 @Mod(Betterinventorysorter.MODID)
 public class Betterinventorysorter {
-    // Define mod id in a common place for everything to reference
     public static final String MODID = "betterinventorysorter";
-    // Directly reference a slf4j logger
     private static final Logger LOGGER = LogUtils.getLogger();
-    // Create a Deferred Register to hold Blocks which will all be registered under the "betterinventorysorter" namespace
-    public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
-    // Create a Deferred Register to hold Items which will all be registered under the "betterinventorysorter" namespace
-    public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
-    // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the "betterinventorysorter" namespace
-    public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MODID);
 
-    // Creates a new Block with the id "betterinventorysorter:example_block", combining the namespace and path
-    public static final DeferredBlock<Block> EXAMPLE_BLOCK = BLOCKS.registerSimpleBlock("example_block", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    // Creates a new BlockItem with the id "betterinventorysorter:example_block", combining the namespace and path
-    public static final DeferredItem<BlockItem> EXAMPLE_BLOCK_ITEM = ITEMS.registerSimpleBlockItem("example_block", EXAMPLE_BLOCK);
-
-    // Creates a new food item with the id "betterinventorysorter:example_id", nutrition 1 and saturation 2
-    public static final DeferredItem<Item> EXAMPLE_ITEM = ITEMS.registerSimpleItem("example_item", new Item.Properties().food(new FoodProperties.Builder().alwaysEdible().nutrition(1).saturationModifier(2f).build()));
-
-    // Creates a creative tab with the id "betterinventorysorter:example_tab" for the example item, that is placed after the combat tab
-    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> EXAMPLE_TAB = CREATIVE_MODE_TABS.register("example_tab", () -> CreativeModeTab.builder().title(Component.translatable("itemGroup.betterinventorysorter")).withTabsBefore(CreativeModeTabs.COMBAT).icon(() -> EXAMPLE_ITEM.get().getDefaultInstance()).displayItems((parameters, output) -> {
-        output.accept(EXAMPLE_ITEM.get()); // Add the example item to the tab. For your own tabs, this method is preferred over the event
-    }).build());
-
-    // The constructor for the mod class is the first code that is run when your mod is loaded.
-    // FML will recognize some parameter types like IEventBus or ModContainer and pass them in automatically.
     public Betterinventorysorter(IEventBus modEventBus, ModContainer modContainer) {
-        // Register the commonSetup method for modloading
         modEventBus.addListener(this::commonSetup);
-
-        // Register the Deferred Register to the mod event bus so blocks get registered
-        BLOCKS.register(modEventBus);
-        // Register the Deferred Register to the mod event bus so items get registered
-        ITEMS.register(modEventBus);
-        // Register the Deferred Register to the mod event bus so tabs get registered
-        CREATIVE_MODE_TABS.register(modEventBus);
-
-        // Register ourselves for server and other game events we are interested in.
-        // Note that this is necessary if and only if we want *this* class (Betterinventorysorter) to respond directly to events.
-        // Do not add this line if there are no @SubscribeEvent-annotated functions in this class, like onServerStarting() below.
-        NeoForge.EVENT_BUS.register(this);
-
-        // Register the item to a creative tab
-        modEventBus.addListener(this::addCreative);
-
-        // Register our mod's ModConfigSpec so that FML can create and load the config file for us
-        modContainer.registerConfig(ModConfig.Type.COMMON, Config.SPEC);
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        // Some common setup code
-        LOGGER.info("HELLO FROM COMMON SETUP");
-
-        if (Config.logDirtBlock) LOGGER.info("DIRT BLOCK >> {}", BuiltInRegistries.BLOCK.getKey(Blocks.DIRT));
-
-        LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
-
-        Config.items.forEach((item) -> LOGGER.info("ITEM >> {}", item.toString()));
-    }
-
-    // Add the example block item to the building blocks tab
-    private void addCreative(BuildCreativeModeTabContentsEvent event) {
-        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) event.accept(EXAMPLE_BLOCK_ITEM);
-    }
-
-    // You can use SubscribeEvent and let the Event Bus discover methods to call
-    @SubscribeEvent
-    public void onServerStarting(ServerStartingEvent event) {
-        // Do something when the server starts
-        LOGGER.info("HELLO from server starting");
-    }
-
-    // You can use EventBusSubscriber to automatically register all static methods in the class annotated with @SubscribeEvent
-    @EventBusSubscriber(modid = MODID, value = Dist.CLIENT)
-    public static class ClientModEvents {
-        @SubscribeEvent
-        public static void onClientSetup(FMLClientSetupEvent event) {
-            // Some client setup code
-            LOGGER.info("HELLO FROM CLIENT SETUP");
-            LOGGER.info("MINECRAFT NAME >> {}", Minecraft.getInstance().getUser().getName());
-        }
+        LOGGER.info("Better Inventory Sorter initialized");
     }
 }

--- a/src/main/java/xyz/bannach/betterinventorysorter/Config.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/Config.java
@@ -1,50 +1,17 @@
 package xyz.bannach.betterinventorysorter;
 
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-// An example config class. This is not required, but it's a good idea to have one to keep your config organized.
-// Demonstrates how to use Neo's config APIs
 @EventBusSubscriber(modid = Betterinventorysorter.MODID)
 public class Config {
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
-    private static final ModConfigSpec.BooleanValue LOG_DIRT_BLOCK = BUILDER.comment("Whether to log the dirt block on common setup").define("logDirtBlock", true);
-
-    private static final ModConfigSpec.IntValue MAGIC_NUMBER = BUILDER.comment("A magic number").defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
-
-    public static final ModConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION = BUILDER.comment("What you want the introduction message to be for the magic number").define("magicNumberIntroduction", "The magic number is... ");
-
-    // a list of strings that are treated as resource locations for items
-    private static final ModConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS = BUILDER.comment("A list of items to log on common setup.").defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), Config::validateItemName);
-
     static final ModConfigSpec SPEC = BUILDER.build();
-
-    public static boolean logDirtBlock;
-    public static int magicNumber;
-    public static String magicNumberIntroduction;
-    public static Set<Item> items = Set.of();
-
-    private static boolean validateItemName(final Object obj) {
-        return obj instanceof String itemName && BuiltInRegistries.ITEM.containsKey(ResourceLocation.parse(itemName));
-    }
 
     @SubscribeEvent
     public static void onLoad(final ModConfigEvent event) {
-        logDirtBlock = LOG_DIRT_BLOCK.get();
-        magicNumber = MAGIC_NUMBER.get();
-        magicNumberIntroduction = MAGIC_NUMBER_INTRODUCTION.get();
-
-        // convert the list of strings into a set of items
-        items = ITEM_STRINGS.get().stream().map(itemName -> BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemName))).collect(Collectors.toSet());
     }
 }

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ClientEvents.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ClientEvents.java
@@ -1,0 +1,21 @@
+package xyz.bannach.betterinventorysorter.client;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ScreenEvent;
+import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+
+@EventBusSubscriber(modid = Betterinventorysorter.MODID, value = Dist.CLIENT)
+public class ClientEvents {
+
+    @SubscribeEvent
+    public static void onKeyPressed(ScreenEvent.KeyPressed.Pre event) {
+        SortKeyHandler.onKeyPressed(event);
+    }
+
+    @SubscribeEvent
+    public static void onMouseClicked(ScreenEvent.MouseButtonPressed.Pre event) {
+        SortKeyHandler.onMouseClicked(event);
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ClientModBusEvents.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ClientModBusEvents.java
@@ -1,0 +1,16 @@
+package xyz.bannach.betterinventorysorter.client;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
+import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+
+@EventBusSubscriber(modid = Betterinventorysorter.MODID, value = Dist.CLIENT)
+public class ClientModBusEvents {
+
+    @SubscribeEvent
+    public static void onRegisterKeyMappings(RegisterKeyMappingsEvent event) {
+        SortKeyHandler.register(event);
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/SortKeyHandler.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/SortKeyHandler.java
@@ -1,0 +1,60 @@
+package xyz.bannach.betterinventorysorter.client;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.logging.LogUtils;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.world.inventory.Slot;
+import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
+import net.neoforged.neoforge.client.event.ScreenEvent;
+import org.lwjgl.glfw.GLFW;
+import org.slf4j.Logger;
+
+public class SortKeyHandler {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    public static final KeyMapping SORT_KEY = new KeyMapping(
+            "key.betterinventorysorter.sort",
+            InputConstants.Type.KEYSYM,
+            GLFW.GLFW_KEY_R,
+            "key.categories.betterinventorysorter"
+    );
+
+    public static void register(RegisterKeyMappingsEvent event) {
+        event.register(SORT_KEY);
+    }
+
+    public static void onKeyPressed(ScreenEvent.KeyPressed.Pre event) {
+        if (!(event.getScreen() instanceof AbstractContainerScreen<?> screen)) {
+            return;
+        }
+        if (SORT_KEY.isActiveAndMatches(InputConstants.getKey(event.getKeyCode(), event.getScanCode()))) {
+            handleSortInput(screen);
+            event.setCanceled(true);
+        }
+    }
+
+    public static void onMouseClicked(ScreenEvent.MouseButtonPressed.Pre event) {
+        if (!(event.getScreen() instanceof AbstractContainerScreen<?> screen)) {
+            return;
+        }
+        if (SORT_KEY.isActiveAndMatches(InputConstants.Type.MOUSE.getOrCreate(event.getButton()))) {
+            handleSortInput(screen);
+            event.setCanceled(true);
+        }
+    }
+
+    private static void handleSortInput(AbstractContainerScreen<?> screen) {
+        LOGGER.info("Sort key pressed on screen: {}", screen.getClass().getSimpleName());
+        LOGGER.info("Menu type: {}", screen.getMenu().getClass().getSimpleName());
+        LOGGER.info("Total slots: {}", screen.getMenu().slots.size());
+
+        Slot hoveredSlot = screen.getSlotUnderMouse();
+        if (hoveredSlot != null) {
+            LOGGER.info("Hovered slot index: {}, container slot: {}, container: {}",
+                    hoveredSlot.index, hoveredSlot.getContainerSlot(), hoveredSlot.container.getClass().getSimpleName());
+        } else {
+            LOGGER.info("No slot hovered");
+        }
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortMethod.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortMethod.java
@@ -1,0 +1,32 @@
+package xyz.bannach.betterinventorysorter.sorting;
+
+import net.minecraft.util.StringRepresentable;
+
+public enum SortMethod implements StringRepresentable {
+    ALPHABETICAL("alphabetical"),
+    CATEGORY("category"),
+    QUANTITY("quantity"),
+    MOD_ID("mod_id");
+
+    public static final com.mojang.serialization.Codec<SortMethod> CODEC = StringRepresentable.fromEnum(SortMethod::values);
+
+    private final String serializedName;
+
+    SortMethod(String serializedName) {
+        this.serializedName = serializedName;
+    }
+
+    @Override
+    public String getSerializedName() {
+        return serializedName;
+    }
+
+    public SortMethod next() {
+        SortMethod[] values = values();
+        return values[(ordinal() + 1) % values.length];
+    }
+
+    public String getTranslationKey() {
+        return "sort_method.betterinventorysorter." + serializedName;
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortOrder.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortOrder.java
@@ -1,0 +1,29 @@
+package xyz.bannach.betterinventorysorter.sorting;
+
+import net.minecraft.util.StringRepresentable;
+
+public enum SortOrder implements StringRepresentable {
+    ASCENDING("ascending"),
+    DESCENDING("descending");
+
+    public static final com.mojang.serialization.Codec<SortOrder> CODEC = StringRepresentable.fromEnum(SortOrder::values);
+
+    private final String serializedName;
+
+    SortOrder(String serializedName) {
+        this.serializedName = serializedName;
+    }
+
+    @Override
+    public String getSerializedName() {
+        return serializedName;
+    }
+
+    public SortOrder toggle() {
+        return this == ASCENDING ? DESCENDING : ASCENDING;
+    }
+
+    public String getTranslationKey() {
+        return "sort_order.betterinventorysorter." + serializedName;
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortPreference.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortPreference.java
@@ -1,0 +1,22 @@
+package xyz.bannach.betterinventorysorter.sorting;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+public record SortPreference(SortMethod method, SortOrder order) {
+
+    public static final SortPreference DEFAULT = new SortPreference(SortMethod.ALPHABETICAL, SortOrder.ASCENDING);
+
+    public static final Codec<SortPreference> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            SortMethod.CODEC.fieldOf("method").forGetter(SortPreference::method),
+            SortOrder.CODEC.fieldOf("order").forGetter(SortPreference::order)
+    ).apply(instance, SortPreference::new));
+
+    public SortPreference withNextMethod() {
+        return new SortPreference(method.next(), order);
+    }
+
+    public SortPreference withToggledOrder() {
+        return new SortPreference(method, order.toggle());
+    }
+}

--- a/src/main/resources/assets/betterinventorysorter/lang/en_us.json
+++ b/src/main/resources/assets/betterinventorysorter/lang/en_us.json
@@ -1,5 +1,10 @@
 {
-  "itemGroup.betterinventorysorter": "Example Mod Tab",
-  "block.betterinventorysorter.example_block": "Example Block",
-  "item.betterinventorysorter.example_item": "Example Item"
+  "sort_method.betterinventorysorter.alphabetical": "Alphabetical",
+  "sort_method.betterinventorysorter.category": "Category",
+  "sort_method.betterinventorysorter.quantity": "Quantity",
+  "sort_method.betterinventorysorter.mod_id": "Mod ID",
+  "sort_order.betterinventorysorter.ascending": "Ascending",
+  "sort_order.betterinventorysorter.descending": "Descending",
+  "key.betterinventorysorter.sort": "Sort Inventory",
+  "key.categories.betterinventorysorter": "Better Inventory Sorter"
 }


### PR DESCRIPTION
## Summary

- Remove boilerplate example code (example blocks, items, creative tabs, and config values) from the mod entrypoint and config classes
- Add client-side keybinding infrastructure: configurable sort key (default: R) with keyboard and mouse input handling in container screens (`ClientEvents`, `ClientModBusEvents`, `SortKeyHandler`)
- Add sorting data model: `SortMethod` (alphabetical, category, quantity, mod ID), `SortOrder` (ascending, descending), and `SortPreference` record with Codec serialization support
- Add localization entries for sort methods, sort orders, and keybinding labels

## Test plan

- [ ] Run `.\gradlew.bat build` to verify compilation
- [ ] Run `.\gradlew.bat runClient`, open an inventory screen, and press R to confirm the sort key fires and logs slot information
- [ ] Verify the keybinding appears under "Better Inventory Sorter" in Options > Controls
- [ ] Rebind the sort key to a mouse button and confirm mouse input handling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)