### PR TITLE
feat: add per-player sort preference persistence and cycling

### DIFF
--- a/src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java
@@ -14,6 +14,7 @@ public class Betterinventorysorter {
 
     public Betterinventorysorter(IEventBus modEventBus, ModContainer modContainer) {
         modEventBus.addListener(this::commonSetup);
+        ModAttachments.ATTACHMENT_TYPES.register(modEventBus);
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {

--- a/src/main/java/xyz/bannach/betterinventorysorter/ModAttachments.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/ModAttachments.java
@@ -1,0 +1,22 @@
+package xyz.bannach.betterinventorysorter;
+
+import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import xyz.bannach.betterinventorysorter.sorting.SortPreference;
+
+import java.util.function.Supplier;
+
+public class ModAttachments {
+
+    public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES =
+            DeferredRegister.create(NeoForgeRegistries.ATTACHMENT_TYPES, Betterinventorysorter.MODID);
+
+    public static final Supplier<AttachmentType<SortPreference>> SORT_PREFERENCE =
+            ATTACHMENT_TYPES.register("sort_preference", () ->
+                    AttachmentType.builder(() -> SortPreference.DEFAULT)
+                            .serialize(SortPreference.CODEC)
+                            .copyOnDeath()
+                            .build()
+            );
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ClientEvents.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ClientEvents.java
@@ -1,5 +1,8 @@
 package xyz.bannach.betterinventorysorter.client;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -17,5 +20,23 @@ public class ClientEvents {
     @SubscribeEvent
     public static void onMouseClicked(ScreenEvent.MouseButtonPressed.Pre event) {
         SortKeyHandler.onMouseClicked(event);
+    }
+
+    @SubscribeEvent
+    public static void onScreenRender(ScreenEvent.Render.Post event) {
+        Component message = ClientPreferenceCache.getDisplayMessage();
+        if (message == null) {
+            return;
+        }
+
+        GuiGraphics guiGraphics = event.getGuiGraphics();
+        var font = Minecraft.getInstance().font;
+        int screenWidth = event.getScreen().width;
+        int textWidth = font.width(message);
+        int x = (screenWidth - textWidth) / 2;
+        int y = 10;
+
+        guiGraphics.fill(x - 4, y - 2, x + textWidth + 4, y + font.lineHeight + 2, 0xAA000000);
+        guiGraphics.drawString(font, message, x, y, 0xFFFFFF);
     }
 }

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ClientPreferenceCache.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ClientPreferenceCache.java
@@ -1,0 +1,53 @@
+package xyz.bannach.betterinventorysorter.client;
+
+import net.minecraft.network.chat.Component;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import xyz.bannach.betterinventorysorter.network.SyncPreferencePayload;
+import xyz.bannach.betterinventorysorter.sorting.SortMethod;
+import xyz.bannach.betterinventorysorter.sorting.SortOrder;
+
+public class ClientPreferenceCache {
+
+    private static final long DISPLAY_DURATION_MS = 2000;
+
+    private static SortMethod method = SortMethod.ALPHABETICAL;
+    private static SortOrder order = SortOrder.ASCENDING;
+    private static boolean initialized = false;
+
+    private static Component displayMessage = null;
+    private static long displayExpiryMs = 0;
+
+    public static void handle(SyncPreferencePayload payload, IPayloadContext context) {
+        context.enqueueWork(() -> update(payload));
+    }
+
+    private static void update(SyncPreferencePayload payload) {
+        method = payload.method();
+        order = payload.order();
+
+        if (!initialized) {
+            initialized = true;
+            return;
+        }
+
+        displayMessage = Component.translatable("message.betterinventorysorter.preference_changed",
+                Component.translatable(method.getTranslationKey()),
+                Component.translatable(order.getTranslationKey()));
+        displayExpiryMs = System.currentTimeMillis() + DISPLAY_DURATION_MS;
+    }
+
+    public static Component getDisplayMessage() {
+        if (displayMessage != null && System.currentTimeMillis() < displayExpiryMs) {
+            return displayMessage;
+        }
+        return null;
+    }
+
+    public static SortMethod getMethod() {
+        return method;
+    }
+
+    public static SortOrder getOrder() {
+        return order;
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/SortKeyHandler.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/SortKeyHandler.java
@@ -2,6 +2,7 @@ package xyz.bannach.betterinventorysorter.client;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
@@ -9,6 +10,7 @@ import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.lwjgl.glfw.GLFW;
+import xyz.bannach.betterinventorysorter.network.CycleMethodPayload;
 import xyz.bannach.betterinventorysorter.network.SortRequestPayload;
 import xyz.bannach.betterinventorysorter.server.SortHandler;
 
@@ -30,6 +32,16 @@ public class SortKeyHandler {
             return;
         }
         if (SORT_KEY.isActiveAndMatches(InputConstants.getKey(event.getKeyCode(), event.getScanCode()))) {
+            if (Screen.hasShiftDown()) {
+                PacketDistributor.sendToServer(new CycleMethodPayload(true));
+                event.setCanceled(true);
+                return;
+            }
+            if (Screen.hasControlDown()) {
+                PacketDistributor.sendToServer(new CycleMethodPayload(false));
+                event.setCanceled(true);
+                return;
+            }
             handleSortInput(screen);
             event.setCanceled(true);
         }
@@ -40,6 +52,16 @@ public class SortKeyHandler {
             return;
         }
         if (SORT_KEY.isActiveAndMatches(InputConstants.Type.MOUSE.getOrCreate(event.getButton()))) {
+            if (Screen.hasShiftDown()) {
+                PacketDistributor.sendToServer(new CycleMethodPayload(true));
+                event.setCanceled(true);
+                return;
+            }
+            if (Screen.hasControlDown()) {
+                PacketDistributor.sendToServer(new CycleMethodPayload(false));
+                event.setCanceled(true);
+                return;
+            }
             handleSortInput(screen);
             event.setCanceled(true);
         }

--- a/src/main/java/xyz/bannach/betterinventorysorter/network/CycleMethodPayload.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/network/CycleMethodPayload.java
@@ -1,0 +1,25 @@
+package xyz.bannach.betterinventorysorter.network;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+
+public record CycleMethodPayload(boolean cycleMethod) implements CustomPacketPayload {
+
+    public static final Type<CycleMethodPayload> TYPE = new Type<>(
+            ResourceLocation.fromNamespaceAndPath(Betterinventorysorter.MODID, "cycle_method")
+    );
+
+    public static final StreamCodec<ByteBuf, CycleMethodPayload> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.BOOL, CycleMethodPayload::cycleMethod,
+            CycleMethodPayload::new
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/network/ModPayloads.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/network/ModPayloads.java
@@ -5,6 +5,8 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+import xyz.bannach.betterinventorysorter.client.ClientPreferenceCache;
+import xyz.bannach.betterinventorysorter.server.PreferenceHandler;
 import xyz.bannach.betterinventorysorter.server.SortHandler;
 
 @EventBusSubscriber(modid = Betterinventorysorter.MODID)
@@ -17,6 +19,16 @@ public class ModPayloads {
                 SortRequestPayload.TYPE,
                 SortRequestPayload.STREAM_CODEC,
                 SortHandler::handle
+        );
+        registrar.playToServer(
+                CycleMethodPayload.TYPE,
+                CycleMethodPayload.STREAM_CODEC,
+                PreferenceHandler::handle
+        );
+        registrar.playToClient(
+                SyncPreferencePayload.TYPE,
+                SyncPreferencePayload.STREAM_CODEC,
+                ClientPreferenceCache::handle
         );
     }
 }

--- a/src/main/java/xyz/bannach/betterinventorysorter/network/SyncPreferencePayload.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/network/SyncPreferencePayload.java
@@ -1,0 +1,52 @@
+package xyz.bannach.betterinventorysorter.network;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+import xyz.bannach.betterinventorysorter.sorting.SortMethod;
+import xyz.bannach.betterinventorysorter.sorting.SortOrder;
+
+public record SyncPreferencePayload(SortMethod method, SortOrder order) implements CustomPacketPayload {
+
+    public static final Type<SyncPreferencePayload> TYPE = new Type<>(
+            ResourceLocation.fromNamespaceAndPath(Betterinventorysorter.MODID, "sync_preference")
+    );
+
+    public static final StreamCodec<ByteBuf, SyncPreferencePayload> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.STRING_UTF8.map(
+                    SyncPreferencePayload::methodFromName,
+                    SortMethod::getSerializedName
+            ), SyncPreferencePayload::method,
+            ByteBufCodecs.STRING_UTF8.map(
+                    SyncPreferencePayload::orderFromName,
+                    SortOrder::getSerializedName
+            ), SyncPreferencePayload::order,
+            SyncPreferencePayload::new
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    private static SortMethod methodFromName(String name) {
+        for (SortMethod m : SortMethod.values()) {
+            if (m.getSerializedName().equals(name)) {
+                return m;
+            }
+        }
+        return SortMethod.ALPHABETICAL;
+    }
+
+    private static SortOrder orderFromName(String name) {
+        for (SortOrder o : SortOrder.values()) {
+            if (o.getSerializedName().equals(name)) {
+                return o;
+            }
+        }
+        return SortOrder.ASCENDING;
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/server/PreferenceHandler.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/server/PreferenceHandler.java
@@ -1,0 +1,28 @@
+package xyz.bannach.betterinventorysorter.server;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.neoforge.network.PacketDistributor;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import xyz.bannach.betterinventorysorter.ModAttachments;
+import xyz.bannach.betterinventorysorter.network.CycleMethodPayload;
+import xyz.bannach.betterinventorysorter.network.SyncPreferencePayload;
+import xyz.bannach.betterinventorysorter.sorting.SortPreference;
+
+public class PreferenceHandler {
+
+    public static void handle(CycleMethodPayload payload, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            ServerPlayer player = (ServerPlayer) context.player();
+            SortPreference current = player.getData(ModAttachments.SORT_PREFERENCE);
+
+            SortPreference updated = payload.cycleMethod()
+                    ? current.withNextMethod()
+                    : current.withToggledOrder();
+
+            player.setData(ModAttachments.SORT_PREFERENCE, updated);
+
+            PacketDistributor.sendToPlayer(player,
+                    new SyncPreferencePayload(updated.method(), updated.order()));
+        });
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/server/ServerEvents.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/server/ServerEvents.java
@@ -1,0 +1,24 @@
+package xyz.bannach.betterinventorysorter.server;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
+import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+import xyz.bannach.betterinventorysorter.ModAttachments;
+import xyz.bannach.betterinventorysorter.network.SyncPreferencePayload;
+import xyz.bannach.betterinventorysorter.sorting.SortPreference;
+
+@EventBusSubscriber(modid = Betterinventorysorter.MODID)
+public class ServerEvents {
+
+    @SubscribeEvent
+    public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            SortPreference pref = player.getData(ModAttachments.SORT_PREFERENCE);
+            PacketDistributor.sendToPlayer(player,
+                    new SyncPreferencePayload(pref.method(), pref.order()));
+        }
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/server/SortHandler.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/server/SortHandler.java
@@ -6,9 +6,9 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
+import xyz.bannach.betterinventorysorter.ModAttachments;
 import xyz.bannach.betterinventorysorter.network.SortRequestPayload;
 import xyz.bannach.betterinventorysorter.sorting.ItemSorter;
-import xyz.bannach.betterinventorysorter.sorting.SortPreference;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +36,7 @@ public class SortHandler {
             }
 
             // Sort stacks
-            List<ItemStack> sorted = ItemSorter.sort(stacks, SortPreference.DEFAULT);
+            List<ItemStack> sorted = ItemSorter.sort(stacks, player.getData(ModAttachments.SORT_PREFERENCE));
 
             // Write sorted stacks back to slots
             for (int i = 0; i < targetSlots.size(); i++) {

--- a/src/main/java/xyz/bannach/betterinventorysorter/test/PreferenceGameTests.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/test/PreferenceGameTests.java
@@ -1,0 +1,143 @@
+package xyz.bannach.betterinventorysorter.test;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+import xyz.bannach.betterinventorysorter.ModAttachments;
+import xyz.bannach.betterinventorysorter.sorting.ItemSorter;
+import xyz.bannach.betterinventorysorter.sorting.SortMethod;
+import xyz.bannach.betterinventorysorter.sorting.SortOrder;
+import xyz.bannach.betterinventorysorter.sorting.SortPreference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@GameTestHolder("betterinventorysorter")
+@PrefixGameTestTemplate(false)
+public class PreferenceGameTests {
+
+    @GameTest(template = "empty")
+    public static void preference_attachment_defaults_correctly(GameTestHelper helper) {
+        Player player = helper.makeMockPlayer(GameType.SURVIVAL);
+        SortPreference pref = player.getData(ModAttachments.SORT_PREFERENCE);
+
+        helper.assertTrue(pref.equals(SortPreference.DEFAULT),
+                "Default preference should be ALPHABETICAL ASCENDING, got " + pref.method().getSerializedName() + " " + pref.order().getSerializedName());
+
+        helper.succeed();
+    }
+
+    @GameTest(template = "empty")
+    public static void preference_attachment_persists_on_player(GameTestHelper helper) {
+        Player player = helper.makeMockPlayer(GameType.SURVIVAL);
+
+        SortPreference custom = new SortPreference(SortMethod.QUANTITY, SortOrder.DESCENDING);
+        player.setData(ModAttachments.SORT_PREFERENCE, custom);
+
+        SortPreference read = player.getData(ModAttachments.SORT_PREFERENCE);
+        helper.assertTrue(read.method() == SortMethod.QUANTITY,
+                "Expected QUANTITY, got " + read.method().getSerializedName());
+        helper.assertTrue(read.order() == SortOrder.DESCENDING,
+                "Expected DESCENDING, got " + read.order().getSerializedName());
+
+        helper.succeed();
+    }
+
+    @GameTest(template = "empty")
+    public static void sort_uses_player_preference(GameTestHelper helper) {
+        Player player = helper.makeMockPlayer(GameType.SURVIVAL);
+        BlockPos chestPos = new BlockPos(1, 1, 1);
+
+        helper.setBlock(chestPos, Blocks.CHEST);
+        ChestBlockEntity chest = (ChestBlockEntity) helper.getBlockEntity(chestPos);
+
+        // Items with different quantities
+        chest.setItem(0, new ItemStack(Items.APPLE, 10));
+        chest.setItem(1, new ItemStack(Items.STONE, 64));
+        chest.setItem(2, new ItemStack(Items.DIAMOND, 32));
+
+        // Set player preference to QUANTITY ASCENDING (highest first by default comparator)
+        SortPreference pref = new SortPreference(SortMethod.QUANTITY, SortOrder.ASCENDING);
+        player.setData(ModAttachments.SORT_PREFERENCE, pref);
+
+        // Open chest and sort
+        ChestMenu menu = ChestMenu.threeRows(0, player.getInventory(), chest);
+
+        List<Slot> containerSlots = new ArrayList<>();
+        for (Slot slot : menu.slots) {
+            if (!(slot.container instanceof net.minecraft.world.entity.player.Inventory)) {
+                containerSlots.add(slot);
+            }
+        }
+
+        List<ItemStack> stacks = new ArrayList<>();
+        for (Slot slot : containerSlots) {
+            stacks.add(slot.getItem().copy());
+        }
+
+        List<ItemStack> sorted = ItemSorter.sort(stacks, player.getData(ModAttachments.SORT_PREFERENCE));
+
+        for (int i = 0; i < containerSlots.size(); i++) {
+            containerSlots.get(i).set(sorted.get(i));
+        }
+
+        // QuantityComparator sorts highest first in ascending order
+        helper.assertTrue(chest.getItem(0).is(Items.STONE),
+                "First slot should be stone (64), got " + chest.getItem(0));
+        helper.assertTrue(chest.getItem(1).is(Items.DIAMOND),
+                "Second slot should be diamond (32), got " + chest.getItem(1));
+        helper.assertTrue(chest.getItem(2).is(Items.APPLE),
+                "Third slot should be apple (10), got " + chest.getItem(2));
+
+        helper.succeed();
+    }
+
+    @GameTest(template = "empty")
+    public static void cycle_method_advances_to_next(GameTestHelper helper) {
+        // ALPHABETICAL -> CATEGORY -> QUANTITY -> MOD_ID -> ALPHABETICAL
+        SortPreference pref = new SortPreference(SortMethod.ALPHABETICAL, SortOrder.ASCENDING);
+
+        pref = pref.withNextMethod();
+        helper.assertTrue(pref.method() == SortMethod.CATEGORY,
+                "Expected CATEGORY after ALPHABETICAL, got " + pref.method().getSerializedName());
+
+        pref = pref.withNextMethod();
+        helper.assertTrue(pref.method() == SortMethod.QUANTITY,
+                "Expected QUANTITY after CATEGORY, got " + pref.method().getSerializedName());
+
+        pref = pref.withNextMethod();
+        helper.assertTrue(pref.method() == SortMethod.MOD_ID,
+                "Expected MOD_ID after QUANTITY, got " + pref.method().getSerializedName());
+
+        pref = pref.withNextMethod();
+        helper.assertTrue(pref.method() == SortMethod.ALPHABETICAL,
+                "Expected ALPHABETICAL after MOD_ID, got " + pref.method().getSerializedName());
+
+        helper.succeed();
+    }
+
+    @GameTest(template = "empty")
+    public static void toggle_order_flips_direction(GameTestHelper helper) {
+        SortPreference pref = new SortPreference(SortMethod.ALPHABETICAL, SortOrder.ASCENDING);
+
+        pref = pref.withToggledOrder();
+        helper.assertTrue(pref.order() == SortOrder.DESCENDING,
+                "Expected DESCENDING after toggling from ASCENDING, got " + pref.order().getSerializedName());
+
+        pref = pref.withToggledOrder();
+        helper.assertTrue(pref.order() == SortOrder.ASCENDING,
+                "Expected ASCENDING after toggling from DESCENDING, got " + pref.order().getSerializedName());
+
+        helper.succeed();
+    }
+}

--- a/src/main/resources/assets/betterinventorysorter/lang/en_us.json
+++ b/src/main/resources/assets/betterinventorysorter/lang/en_us.json
@@ -5,6 +5,7 @@
   "sort_method.betterinventorysorter.mod_id": "Mod ID",
   "sort_order.betterinventorysorter.ascending": "Ascending",
   "sort_order.betterinventorysorter.descending": "Descending",
+  "message.betterinventorysorter.preference_changed": "Sort: %s (%s)",
   "key.betterinventorysorter.sort": "Sort Inventory",
   "key.categories.betterinventorysorter": "Better Inventory Sorter"
 }


### PR DESCRIPTION
## Summary
- Persist each player's sort method and order across sessions using NeoForge Data Attachments (`SORT_PREFERENCE` with `copyOnDeath`)
- Add **Shift+R** to cycle sort method (Alphabetical → Category → Quantity → Mod ID) and **Ctrl+R** to toggle ascending/descending
- Sync preferences from server to client on login and on change, with an on-screen overlay notification
- Sort handler now reads the player's stored preference instead of using the hardcoded default

## Test plan
- [x] `.\gradlew.bat build` succeeds
- [x] `.\gradlew.bat runGameTestServer` passes (5 new preference tests + existing 18)
- [ ] Manual: Open a chest, press Shift+R — overlay shows updated sort method at top of screen
- [ ] Manual: Press Ctrl+R — overlay shows toggled sort order
- [ ] Manual: Press R — inventory sorts using the selected preference
- [ ] Manual: Disconnect and reconnect — preference persists across sessions
- [ ] Manual: No overlay message appears on initial login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

resolves: #5 