### PR TITLE
feat: add visual feedback and configurable defaults for sorting

### DIFF
--- a/src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java
@@ -17,6 +17,7 @@ public class Betterinventorysorter {
         modEventBus.addListener(this::commonSetup);
         ModAttachments.ATTACHMENT_TYPES.register(modEventBus);
         modContainer.registerConfig(ModConfig.Type.CLIENT, Config.CLIENT_SPEC);
+        modContainer.registerConfig(ModConfig.Type.SERVER, Config.SERVER_SPEC);
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {

--- a/src/main/java/xyz/bannach/betterinventorysorter/Config.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/Config.java
@@ -4,23 +4,39 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
+import xyz.bannach.betterinventorysorter.sorting.SortMethod;
+import xyz.bannach.betterinventorysorter.sorting.SortOrder;
 
 @EventBusSubscriber(modid = Betterinventorysorter.MODID)
 public class Config {
     private static final ModConfigSpec.Builder CLIENT_BUILDER = new ModConfigSpec.Builder();
+    private static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
 
     private static final ModConfigSpec.BooleanValue SHOW_SORT_BUTTON = CLIENT_BUILDER
             .comment("Show the sort button on supported container screens")
             .define("showSortButton", true);
 
+    private static final ModConfigSpec.EnumValue<SortMethod> DEFAULT_SORT_METHOD = SERVER_BUILDER
+            .comment("Default sort method for new players")
+            .defineEnum("defaultSortMethod", SortMethod.ALPHABETICAL);
+    private static final ModConfigSpec.EnumValue<SortOrder> DEFAULT_SORT_ORDER = SERVER_BUILDER
+            .comment("Default sort order for new players")
+            .defineEnum("defaultSortOrder", SortOrder.ASCENDING);
+
     static final ModConfigSpec CLIENT_SPEC = CLIENT_BUILDER.build();
+    static final ModConfigSpec SERVER_SPEC = SERVER_BUILDER.build();
 
     public static boolean showSortButton = true;
+    public static SortMethod defaultSortMethod = SortMethod.ALPHABETICAL;
+    public static SortOrder defaultSortOrder = SortOrder.ASCENDING;
 
     @SubscribeEvent
-    public static void onLoad(final ModConfigEvent event) {
+    public static void onLoad(final ModConfigEvent.Loading event) {
         if (event.getConfig().getSpec() == CLIENT_SPEC) {
             showSortButton = SHOW_SORT_BUTTON.get();
+        } else if (event.getConfig().getSpec() == SERVER_SPEC) {
+            defaultSortMethod = DEFAULT_SORT_METHOD.get();
+            defaultSortOrder = DEFAULT_SORT_ORDER.get();
         }
     }
 }

--- a/src/main/java/xyz/bannach/betterinventorysorter/ModAttachments.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/ModAttachments.java
@@ -14,7 +14,7 @@ public class ModAttachments {
 
     public static final Supplier<AttachmentType<SortPreference>> SORT_PREFERENCE =
             ATTACHMENT_TYPES.register("sort_preference", () ->
-                    AttachmentType.builder(() -> SortPreference.DEFAULT)
+                    AttachmentType.builder(() -> new SortPreference(Config.defaultSortMethod, Config.defaultSortOrder))
                             .serialize(SortPreference.CODEC)
                             .copyOnDeath()
                             .build()

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ClientEvents.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ClientEvents.java
@@ -29,7 +29,7 @@ public class ClientEvents {
 
     @SubscribeEvent
     public static void onScreenRender(ScreenEvent.Render.Post event) {
-        Component message = ClientPreferenceCache.getDisplayMessage();
+        Component message = SortFeedback.getDisplayMessage();
         if (message == null) {
             return;
         }

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/SortButton.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/SortButton.java
@@ -25,7 +25,8 @@ public class SortButton extends Button {
     private final int sortRegion;
 
     public SortButton(AbstractContainerScreen<?> parentScreen, int sortRegion) {
-        super(0, 0, SIZE, SIZE, Component.empty(), b -> {}, DEFAULT_NARRATION);
+        super(0, 0, SIZE, SIZE, Component.empty(), b -> {
+        }, DEFAULT_NARRATION);
         this.parentScreen = parentScreen;
         this.sortRegion = sortRegion;
     }
@@ -34,10 +35,13 @@ public class SortButton extends Button {
     public void onPress() {
         if (Screen.hasShiftDown()) {
             PacketDistributor.sendToServer(new CycleMethodPayload(true));
+            SortFeedback.showPreferenceChange(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
         } else if (Screen.hasControlDown()) {
             PacketDistributor.sendToServer(new CycleMethodPayload(false));
+            SortFeedback.showPreferenceChange(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
         } else {
             PacketDistributor.sendToServer(new SortRequestPayload(sortRegion));
+            SortFeedback.showSorted(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
         }
     }
 

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/SortFeedback.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/SortFeedback.java
@@ -1,0 +1,39 @@
+package xyz.bannach.betterinventorysorter.client;
+
+import net.minecraft.network.chat.Component;
+import xyz.bannach.betterinventorysorter.sorting.SortMethod;
+import xyz.bannach.betterinventorysorter.sorting.SortOrder;
+
+public class SortFeedback {
+
+    private static final long DISPLAY_DURATION_MS = 2000;
+
+    private static Component displayMessage = null;
+    private static long displayExpiryMs = 0;
+
+    public static void showSorted(SortMethod method, SortOrder order) {
+        Component message = Component.translatable("message.betterinventorysorter.sorted",
+                Component.translatable(method.getTranslationKey()),
+                Component.translatable(order.getTranslationKey()));
+        displayOverlay(message);
+    }
+
+    public static void showPreferenceChange(SortMethod method, SortOrder order) {
+        Component message = Component.translatable("message.betterinventorysorter.preference_changed",
+                Component.translatable(method.getTranslationKey()),
+                Component.translatable(order.getTranslationKey()));
+        displayOverlay(message);
+    }
+
+    private static void displayOverlay(Component message) {
+        displayMessage = message;
+        displayExpiryMs = System.currentTimeMillis() + DISPLAY_DURATION_MS;
+    }
+
+    public static Component getDisplayMessage() {
+        if (displayMessage != null && System.currentTimeMillis() < displayExpiryMs) {
+            return displayMessage;
+        }
+        return null;
+    }
+}

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/SortKeyHandler.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/SortKeyHandler.java
@@ -34,11 +34,13 @@ public class SortKeyHandler {
         if (SORT_KEY.isActiveAndMatches(InputConstants.getKey(event.getKeyCode(), event.getScanCode()))) {
             if (Screen.hasShiftDown()) {
                 PacketDistributor.sendToServer(new CycleMethodPayload(true));
+                SortFeedback.showPreferenceChange(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
                 event.setCanceled(true);
                 return;
             }
             if (Screen.hasControlDown()) {
                 PacketDistributor.sendToServer(new CycleMethodPayload(false));
+                SortFeedback.showPreferenceChange(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
                 event.setCanceled(true);
                 return;
             }
@@ -54,11 +56,13 @@ public class SortKeyHandler {
         if (SORT_KEY.isActiveAndMatches(InputConstants.Type.MOUSE.getOrCreate(event.getButton()))) {
             if (Screen.hasShiftDown()) {
                 PacketDistributor.sendToServer(new CycleMethodPayload(true));
+                SortFeedback.showPreferenceChange(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
                 event.setCanceled(true);
                 return;
             }
             if (Screen.hasControlDown()) {
                 PacketDistributor.sendToServer(new CycleMethodPayload(false));
+                SortFeedback.showPreferenceChange(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
                 event.setCanceled(true);
                 return;
             }
@@ -75,6 +79,7 @@ public class SortKeyHandler {
 
         int region = determineRegion(hoveredSlot);
         PacketDistributor.sendToServer(new SortRequestPayload(region));
+        SortFeedback.showSorted(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
     }
 
     private static int determineRegion(Slot slot) {

--- a/src/main/resources/assets/betterinventorysorter/lang/en_us.json
+++ b/src/main/resources/assets/betterinventorysorter/lang/en_us.json
@@ -6,6 +6,7 @@
   "sort_order.betterinventorysorter.ascending": "Ascending",
   "sort_order.betterinventorysorter.descending": "Descending",
   "message.betterinventorysorter.preference_changed": "Sort: %s (%s)",
+  "message.betterinventorysorter.sorted": "Sorted: %s (%s)",
   "key.betterinventorysorter.sort": "Sort Inventory",
   "key.categories.betterinventorysorter": "Better Inventory Sorter",
   "tooltip.betterinventorysorter.sort_button": "Sort: %s (%s)",


### PR DESCRIPTION
## Summary

Implements issue #8 - adds visual feedback when sorting occurs or preferences change, plus server-side configuration for default sort preferences.

## Changes

- **SortFeedback.java**: New centralized feedback system that displays overlay messages at the top of the screen (y=10) to avoid GUI scale issues with action bar
- **User feedback**: Shows "Sorted: {Method} ({Order})" when sorting, and "Sort: {Method} ({Order})" when cycling method or toggling order
- **SortKeyHandler & SortButton**: Trigger feedback display on all sort and preference change actions
- **ClientPreferenceCache**: Refactored to use SortFeedback for displaying server-synced preference changes
- **Server config**: Added `defaultSortMethod` and `defaultSortOrder` config options for new players
- **ModAttachments**: Uses configurable defaults when creating new player preferences
- **Translation**: Added `message.betterinventorysorter.sorted` key
- **Bug fix**: Resolved config unloading exception by using `ModConfigEvent.Loading` instead of base event

## Testing

- [x] Build succeeds
- [x] All 31 game tests pass
- [x] No exceptions during server startup or shutdown

## Closes

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)