### PR TITLE
docs: add comprehensive Javadoc documentation

### DIFF
--- a/src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/Betterinventorysorter.java
@@ -8,11 +8,50 @@ import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import org.slf4j.Logger;
 
+/**
+ * Main entrypoint for the Better Inventory Sorter mod.
+ *
+ * <p>This class is annotated with {@link Mod} and serves as the primary initialization
+ * point for the mod. It registers data attachments, configuration files, and sets up
+ * the mod event bus listeners.</p>
+ *
+ * <h2>Responsibilities</h2>
+ * <ul>
+ *   <li>Register {@link ModAttachments} for player sort preferences</li>
+ *   <li>Register client and server configuration files</li>
+ *   <li>Log initialization message on common setup</li>
+ * </ul>
+ *
+ * <h2>Side: Common</h2>
+ * <p>This class is loaded on both client and server sides.</p>
+ *
+ * @since 1.0.0
+ * @see Config
+ * @see ModAttachments
+ */
 @Mod(Betterinventorysorter.MODID)
 public class Betterinventorysorter {
+
+    /**
+     * The mod identifier used throughout the mod for registration and resource locations.
+     * Value: {@value #MODID}
+     */
     public static final String MODID = "betterinventorysorter";
+
+    /**
+     * Logger instance for this class.
+     */
     private static final Logger LOGGER = LogUtils.getLogger();
 
+    /**
+     * Constructs the mod instance and performs all necessary registrations.
+     *
+     * <p>This constructor is called by NeoForge during mod loading. It registers
+     * the common setup listener, attachment types, and configuration specifications.</p>
+     *
+     * @param modEventBus the mod-specific event bus for registering listeners
+     * @param modContainer the container providing access to mod metadata and config registration
+     */
     public Betterinventorysorter(IEventBus modEventBus, ModContainer modContainer) {
         modEventBus.addListener(this::commonSetup);
         ModAttachments.ATTACHMENT_TYPES.register(modEventBus);
@@ -20,6 +59,13 @@ public class Betterinventorysorter {
         modContainer.registerConfig(ModConfig.Type.SERVER, Config.SERVER_SPEC);
     }
 
+    /**
+     * Handles the common setup event, called after all mods have been constructed.
+     *
+     * <p>This method logs an initialization message to confirm the mod has loaded successfully.</p>
+     *
+     * @param event the common setup event fired during mod loading
+     */
     private void commonSetup(final FMLCommonSetupEvent event) {
         LOGGER.info("Better Inventory Sorter initialized");
     }

--- a/src/main/java/xyz/bannach/betterinventorysorter/Config.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/Config.java
@@ -7,29 +7,113 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 import xyz.bannach.betterinventorysorter.sorting.SortMethod;
 import xyz.bannach.betterinventorysorter.sorting.SortOrder;
 
+/**
+ * Configuration management for the Better Inventory Sorter mod.
+ *
+ * <p>This class defines and manages both client-side and server-side configuration options
+ * using NeoForge's {@link ModConfigSpec} system. Configuration values are automatically
+ * loaded and updated when config files change.</p>
+ *
+ * <h2>Client Configuration</h2>
+ * <ul>
+ *   <li>{@link #showSortButton} - Whether to display the sort button on container screens</li>
+ * </ul>
+ *
+ * <h2>Server Configuration</h2>
+ * <ul>
+ *   <li>{@link #defaultSortMethod} - Default sort method for new players</li>
+ *   <li>{@link #defaultSortOrder} - Default sort order for new players</li>
+ * </ul>
+ *
+ * <h2>Side: Common</h2>
+ * <p>This class is loaded on both sides, but client config only applies client-side
+ * and server config only applies server-side.</p>
+ *
+ * @since 1.0.0
+ * @see Betterinventorysorter
+ * @see SortMethod
+ * @see SortOrder
+ */
 @EventBusSubscriber(modid = Betterinventorysorter.MODID)
 public class Config {
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private Config() {}
+
+    /**
+     * Builder for client-side configuration options.
+     */
     private static final ModConfigSpec.Builder CLIENT_BUILDER = new ModConfigSpec.Builder();
+
+    /**
+     * Builder for server-side configuration options.
+     */
     private static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
 
+    /**
+     * Config value for whether to show the sort button on container screens.
+     */
     private static final ModConfigSpec.BooleanValue SHOW_SORT_BUTTON = CLIENT_BUILDER
             .comment("Show the sort button on supported container screens")
             .define("showSortButton", true);
 
+    /**
+     * Config value for the default sort method applied to new players.
+     */
     private static final ModConfigSpec.EnumValue<SortMethod> DEFAULT_SORT_METHOD = SERVER_BUILDER
             .comment("Default sort method for new players")
             .defineEnum("defaultSortMethod", SortMethod.ALPHABETICAL);
+
+    /**
+     * Config value for the default sort order applied to new players.
+     */
     private static final ModConfigSpec.EnumValue<SortOrder> DEFAULT_SORT_ORDER = SERVER_BUILDER
             .comment("Default sort order for new players")
             .defineEnum("defaultSortOrder", SortOrder.ASCENDING);
 
+    /**
+     * The built client configuration specification.
+     * Registered in {@link Betterinventorysorter}.
+     */
     static final ModConfigSpec CLIENT_SPEC = CLIENT_BUILDER.build();
+
+    /**
+     * The built server configuration specification.
+     * Registered in {@link Betterinventorysorter}.
+     */
     static final ModConfigSpec SERVER_SPEC = SERVER_BUILDER.build();
 
+    /**
+     * Whether to show the sort button on supported container screens.
+     * <p>Default: {@code true}</p>
+     * <p>Side: Client only</p>
+     */
     public static boolean showSortButton = true;
+
+    /**
+     * The default sort method assigned to new players.
+     * <p>Default: {@link SortMethod#ALPHABETICAL}</p>
+     * <p>Side: Server only</p>
+     */
     public static SortMethod defaultSortMethod = SortMethod.ALPHABETICAL;
+
+    /**
+     * The default sort order assigned to new players.
+     * <p>Default: {@link SortOrder#ASCENDING}</p>
+     * <p>Side: Server only</p>
+     */
     public static SortOrder defaultSortOrder = SortOrder.ASCENDING;
 
+    /**
+     * Handles configuration loading events.
+     *
+     * <p>Updates the static configuration fields when config files are loaded or reloaded.
+     * Client and server configs are handled separately based on the spec.</p>
+     *
+     * @param event the config loading event containing the loaded configuration
+     */
     @SubscribeEvent
     public static void onLoad(final ModConfigEvent.Loading event) {
         if (event.getConfig().getSpec() == CLIENT_SPEC) {

--- a/src/main/java/xyz/bannach/betterinventorysorter/ModAttachments.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/ModAttachments.java
@@ -7,11 +7,50 @@ import xyz.bannach.betterinventorysorter.sorting.SortPreference;
 
 import java.util.function.Supplier;
 
+/**
+ * Registry for player data attachments used by the mod.
+ *
+ * <p>This class registers NeoForge data attachments that persist player-specific data.
+ * Attachments are automatically saved with player data and can be configured to persist
+ * across death.</p>
+ *
+ * <h2>Registered Attachments</h2>
+ * <ul>
+ *   <li>{@link #SORT_PREFERENCE} - Stores the player's sort method and order preferences</li>
+ * </ul>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Attachments are registered on both sides but primarily used server-side for persistence.</p>
+ *
+ * @since 1.0.0
+ * @see SortPreference
+ * @see Betterinventorysorter
+ */
 public class ModAttachments {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private ModAttachments() {}
+
+    /**
+     * Deferred register for attachment types.
+     * <p>Registered to the mod event bus in {@link Betterinventorysorter}.</p>
+     */
     public static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES =
             DeferredRegister.create(NeoForgeRegistries.ATTACHMENT_TYPES, Betterinventorysorter.MODID);
 
+    /**
+     * Player attachment for storing sort preferences.
+     *
+     * <p>This attachment stores a {@link SortPreference} containing the player's chosen
+     * sort method and order. The attachment has the following properties:</p>
+     * <ul>
+     *   <li>Default value: Created from {@link Config#defaultSortMethod} and {@link Config#defaultSortOrder}</li>
+     *   <li>Serialization: Uses {@link SortPreference#CODEC} for NBT persistence</li>
+     *   <li>Death behavior: Preserved across player death (copyOnDeath)</li>
+     * </ul>
+     */
     public static final Supplier<AttachmentType<SortPreference>> SORT_PREFERENCE =
             ATTACHMENT_TYPES.register("sort_preference", () ->
                     AttachmentType.builder(() -> new SortPreference(Config.defaultSortMethod, Config.defaultSortOrder))

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ClientEvents.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ClientEvents.java
@@ -9,24 +9,84 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ScreenEvent;
 import xyz.bannach.betterinventorysorter.Betterinventorysorter;
 
+/**
+ * Client-side event handlers for screen interactions and rendering.
+ *
+ * <p>This class listens to NeoForge screen events on the client side and delegates
+ * to the appropriate handler classes. It handles keyboard input, mouse input,
+ * screen initialization, and overlay rendering.</p>
+ *
+ * <h2>Handled Events</h2>
+ * <ul>
+ *   <li>{@link ScreenEvent.KeyPressed.Pre} - Keyboard input for sort/cycle keybinds</li>
+ *   <li>{@link ScreenEvent.MouseButtonPressed.Pre} - Mouse input for sort/cycle keybinds</li>
+ *   <li>{@link ScreenEvent.Init.Post} - Screen initialization for button injection</li>
+ *   <li>{@link ScreenEvent.Render.Post} - Screen rendering for feedback overlay</li>
+ * </ul>
+ *
+ * <h2>Side: Client-only</h2>
+ * <p>This class is only loaded on the client via {@link Dist#CLIENT}.</p>
+ *
+ * @since 1.0.0
+ * @see SortKeyHandler
+ * @see ScreenButtonInjector
+ * @see SortFeedback
+ */
 @EventBusSubscriber(modid = Betterinventorysorter.MODID, value = Dist.CLIENT)
 public class ClientEvents {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private ClientEvents() {}
+
+    /**
+     * Handles keyboard input events on screens.
+     *
+     * <p>Delegates to {@link SortKeyHandler#onKeyPressed(ScreenEvent.KeyPressed.Pre)}
+     * for processing sort and preference cycle keybinds.</p>
+     *
+     * @param event the key pressed event
+     */
     @SubscribeEvent
     public static void onKeyPressed(ScreenEvent.KeyPressed.Pre event) {
         SortKeyHandler.onKeyPressed(event);
     }
 
+    /**
+     * Handles mouse button input events on screens.
+     *
+     * <p>Delegates to {@link SortKeyHandler#onMouseClicked(ScreenEvent.MouseButtonPressed.Pre)}
+     * for processing sort and preference cycle keybinds bound to mouse buttons.</p>
+     *
+     * @param event the mouse button pressed event
+     */
     @SubscribeEvent
     public static void onMouseClicked(ScreenEvent.MouseButtonPressed.Pre event) {
         SortKeyHandler.onMouseClicked(event);
     }
 
+    /**
+     * Handles screen initialization events.
+     *
+     * <p>Delegates to {@link ScreenButtonInjector#onScreenInit(ScreenEvent.Init.Post)}
+     * to inject sort buttons into supported container screens.</p>
+     *
+     * @param event the screen initialization event
+     */
     @SubscribeEvent
     public static void onScreenInit(ScreenEvent.Init.Post event) {
         ScreenButtonInjector.onScreenInit(event);
     }
 
+    /**
+     * Handles screen render events to display feedback overlays.
+     *
+     * <p>Renders the current feedback message (if any) as a centered overlay
+     * at the top of the screen with a semi-transparent background.</p>
+     *
+     * @param event the screen render event
+     */
     @SubscribeEvent
     public static void onScreenRender(ScreenEvent.Render.Post event) {
         Component message = SortFeedback.getDisplayMessage();

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ClientModBusEvents.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ClientModBusEvents.java
@@ -6,9 +6,39 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import xyz.bannach.betterinventorysorter.Betterinventorysorter;
 
+/**
+ * Client-side mod bus event handlers.
+ *
+ * <p>This class listens to events on the mod event bus (as opposed to the game event bus)
+ * that are specific to client-side initialization, such as key mapping registration.</p>
+ *
+ * <h2>Handled Events</h2>
+ * <ul>
+ *   <li>{@link RegisterKeyMappingsEvent} - Registers mod keybindings with the game</li>
+ * </ul>
+ *
+ * <h2>Side: Client-only</h2>
+ * <p>This class is only loaded on the client via {@link Dist#CLIENT}.</p>
+ *
+ * @since 1.0.0
+ * @see SortKeyHandler
+ */
 @EventBusSubscriber(modid = Betterinventorysorter.MODID, value = Dist.CLIENT)
 public class ClientModBusEvents {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private ClientModBusEvents() {}
+
+    /**
+     * Handles key mapping registration.
+     *
+     * <p>Delegates to {@link SortKeyHandler#register(RegisterKeyMappingsEvent)}
+     * to register the sort and preference cycle keybindings.</p>
+     *
+     * @param event the key mapping registration event
+     */
     @SubscribeEvent
     public static void onRegisterKeyMappings(RegisterKeyMappingsEvent event) {
         SortKeyHandler.register(event);

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ClientPreferenceCache.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ClientPreferenceCache.java
@@ -5,16 +5,71 @@ import xyz.bannach.betterinventorysorter.network.SyncPreferencePayload;
 import xyz.bannach.betterinventorysorter.sorting.SortMethod;
 import xyz.bannach.betterinventorysorter.sorting.SortOrder;
 
+/**
+ * Client-side cache for the player's sort preferences.
+ *
+ * <p>This class maintains a local copy of the player's sort preferences on the client
+ * for use in UI elements such as tooltips and feedback messages. The cache is updated
+ * when the server sends a {@link SyncPreferencePayload}.</p>
+ *
+ * <h2>Usage</h2>
+ * <p>Access the current preferences via {@link #getMethod()} and {@link #getOrder()}.
+ * These values are updated automatically when sync packets arrive.</p>
+ *
+ * <h2>Side: Client-only</h2>
+ * <p>This cache only exists on the client. The authoritative preferences are stored
+ * server-side in player data attachments.</p>
+ *
+ * @since 1.0.0
+ * @see SyncPreferencePayload
+ * @see SortFeedback
+ */
 public class ClientPreferenceCache {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private ClientPreferenceCache() {}
+
+    /**
+     * The cached sort method.
+     * <p>Default: {@link SortMethod#ALPHABETICAL}</p>
+     */
     private static SortMethod method = SortMethod.ALPHABETICAL;
+
+    /**
+     * The cached sort order.
+     * <p>Default: {@link SortOrder#ASCENDING}</p>
+     */
     private static SortOrder order = SortOrder.ASCENDING;
+
+    /**
+     * Whether the cache has been initialized with server data.
+     * <p>Used to suppress feedback on initial sync during login.</p>
+     */
     private static boolean initialized = false;
 
+    /**
+     * Handles incoming preference sync payloads from the server.
+     *
+     * <p>This method is registered as the packet handler for {@link SyncPreferencePayload}
+     * and enqueues the cache update on the client thread.</p>
+     *
+     * @param payload the sync payload containing the new preferences
+     * @param context the network context
+     */
     public static void handle(SyncPreferencePayload payload, IPayloadContext context) {
         context.enqueueWork(() -> update(payload));
     }
 
+    /**
+     * Updates the cached preferences from a sync payload.
+     *
+     * <p>If this is the first sync (during login), no feedback is shown. For subsequent
+     * updates, feedback is displayed if the preferences changed.</p>
+     *
+     * @param payload the sync payload containing the new preferences
+     */
     private static void update(SyncPreferencePayload payload) {
         SortMethod oldMethod = method;
         SortOrder oldOrder = order;
@@ -33,10 +88,20 @@ public class ClientPreferenceCache {
         }
     }
 
+    /**
+     * Returns the cached sort method.
+     *
+     * @return the player's current sort method
+     */
     public static SortMethod getMethod() {
         return method;
     }
 
+    /**
+     * Returns the cached sort order.
+     *
+     * @return the player's current sort order
+     */
     public static SortOrder getOrder() {
         return order;
     }

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/ScreenButtonInjector.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/ScreenButtonInjector.java
@@ -8,8 +8,46 @@ import net.neoforged.neoforge.client.event.ScreenEvent;
 import xyz.bannach.betterinventorysorter.Config;
 import xyz.bannach.betterinventorysorter.server.SortHandler;
 
+/**
+ * Injects sort buttons into supported container screens.
+ *
+ * <p>This class handles the automatic addition of {@link SortButton} widgets to
+ * container screens during their initialization. The button is positioned to the
+ * right of the container GUI.</p>
+ *
+ * <h2>Supported Screens</h2>
+ * <ul>
+ *   <li>{@link ChestMenu} - Single and double chests</li>
+ *   <li>{@link ShulkerBoxMenu} - Shulker boxes</li>
+ *   <li>{@link InventoryMenu} - Player inventory screen</li>
+ * </ul>
+ *
+ * <h2>Configuration</h2>
+ * <p>Button injection can be disabled via the {@link Config#showSortButton} setting.</p>
+ *
+ * <h2>Side: Client-only</h2>
+ * <p>Button injection only occurs on the client.</p>
+ *
+ * @since 1.0.0
+ * @see SortButton
+ * @see Config#showSortButton
+ */
 public class ScreenButtonInjector {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private ScreenButtonInjector() {}
+
+    /**
+     * Handles screen initialization to inject sort buttons.
+     *
+     * <p>Called after a screen is initialized. If the screen is a supported container
+     * type and the button is enabled in config, a {@link SortButton} is added to the
+     * screen's widget list.</p>
+     *
+     * @param event the screen initialization event
+     */
     public static void onScreenInit(ScreenEvent.Init.Post event) {
         if (!Config.showSortButton) {
             return;

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/SortButton.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/SortButton.java
@@ -9,17 +9,65 @@ import net.neoforged.neoforge.network.PacketDistributor;
 import xyz.bannach.betterinventorysorter.Betterinventorysorter;
 import xyz.bannach.betterinventorysorter.network.SortRequestPayload;
 
+/**
+ * A clickable button widget that triggers inventory sorting.
+ *
+ * <p>This button is injected into supported container screens by {@link ScreenButtonInjector}.
+ * It displays a custom texture icon and shows a tooltip with the current sort preferences
+ * when hovered. Clicking the button sends a sort request to the server.</p>
+ *
+ * <h2>Positioning</h2>
+ * <p>The button positions itself to the right of the parent screen's GUI area,
+ * updating its position each frame to handle screen resizing.</p>
+ *
+ * <h2>Appearance</h2>
+ * <ul>
+ *   <li>Size: 16x16 pixels</li>
+ *   <li>Background: Semi-transparent dark gray</li>
+ *   <li>Icon: Custom texture from mod resources</li>
+ *   <li>Tooltip: Shows current sort method and order when hovered</li>
+ * </ul>
+ *
+ * <h2>Side: Client-only</h2>
+ * <p>This widget only exists on the client.</p>
+ *
+ * @since 1.0.0
+ * @see ScreenButtonInjector
+ * @see SortRequestPayload
+ */
 public class SortButton extends Button {
 
+    /**
+     * The texture resource location for the button icon.
+     */
     private static final ResourceLocation TEXTURE = ResourceLocation.fromNamespaceAndPath(
             Betterinventorysorter.MODID, "textures/gui/sort_button.png"
     );
 
+    /**
+     * The size of the button in pixels (both width and height).
+     */
     private static final int SIZE = 16;
 
+    /**
+     * The parent container screen this button is attached to.
+     */
     private final AbstractContainerScreen<?> parentScreen;
+
+    /**
+     * The inventory region this button will sort when clicked.
+     */
     private final int sortRegion;
 
+    /**
+     * Constructs a new sort button for the given screen and region.
+     *
+     * <p>The button's position is set dynamically during rendering based on
+     * the parent screen's GUI position.</p>
+     *
+     * @param parentScreen the container screen this button is attached to
+     * @param sortRegion the inventory region to sort (see {@link xyz.bannach.betterinventorysorter.server.SortHandler})
+     */
     public SortButton(AbstractContainerScreen<?> parentScreen, int sortRegion) {
         super(0, 0, SIZE, SIZE, Component.empty(), b -> {
         }, DEFAULT_NARRATION);
@@ -27,12 +75,28 @@ public class SortButton extends Button {
         this.sortRegion = sortRegion;
     }
 
+    /**
+     * Handles button press by sending a sort request to the server.
+     *
+     * <p>Also displays visual feedback to the player showing the current sort settings.</p>
+     */
     @Override
     public void onPress() {
         PacketDistributor.sendToServer(new SortRequestPayload(sortRegion));
         SortFeedback.showSorted(ClientPreferenceCache.getMethod(), ClientPreferenceCache.getOrder());
     }
 
+    /**
+     * Renders the button widget.
+     *
+     * <p>This method updates the button's position based on the parent screen,
+     * draws the background and icon texture, and renders a tooltip when hovered.</p>
+     *
+     * @param guiGraphics the graphics context for rendering
+     * @param mouseX the current mouse X position
+     * @param mouseY the current mouse Y position
+     * @param partialTick the partial tick for smooth animations
+     */
     @Override
     protected void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         setX(parentScreen.getGuiLeft() + parentScreen.getXSize() + 2);

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/SortFeedback.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/SortFeedback.java
@@ -4,13 +4,61 @@ import net.minecraft.network.chat.Component;
 import xyz.bannach.betterinventorysorter.sorting.SortMethod;
 import xyz.bannach.betterinventorysorter.sorting.SortOrder;
 
+/**
+ * Manages visual feedback messages displayed to the player.
+ *
+ * <p>This class provides a simple overlay message system that displays temporary
+ * feedback when sorting is performed or preferences are changed. Messages are
+ * displayed for a fixed duration before automatically expiring.</p>
+ *
+ * <h2>Message Types</h2>
+ * <ul>
+ *   <li>{@link #showSorted(SortMethod, SortOrder)} - Displayed after a sort operation</li>
+ *   <li>{@link #showPreferenceChange(SortMethod, SortOrder)} - Displayed when preferences change</li>
+ * </ul>
+ *
+ * <h2>Rendering</h2>
+ * <p>Messages are rendered by {@link ClientEvents#onScreenRender(net.neoforged.neoforge.client.event.ScreenEvent.Render.Post)}
+ * as a centered overlay at the top of the screen.</p>
+ *
+ * <h2>Side: Client-only</h2>
+ * <p>Feedback is purely visual and only exists on the client.</p>
+ *
+ * @since 1.0.0
+ * @see ClientEvents
+ */
 public class SortFeedback {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private SortFeedback() {}
+
+    /**
+     * Duration in milliseconds that feedback messages are displayed.
+     * <p>Value: {@value} ms (2 seconds)</p>
+     */
     private static final long DISPLAY_DURATION_MS = 2000;
 
+    /**
+     * The current message being displayed, or null if none.
+     */
     private static Component displayMessage = null;
+
+    /**
+     * Timestamp (in system milliseconds) when the current message expires.
+     */
     private static long displayExpiryMs = 0;
 
+    /**
+     * Displays a feedback message indicating that sorting was performed.
+     *
+     * <p>The message uses the translation key "message.betterinventorysorter.sorted"
+     * with the method and order as parameters.</p>
+     *
+     * @param method the sort method that was used
+     * @param order the sort order that was used
+     */
     public static void showSorted(SortMethod method, SortOrder order) {
         Component message = Component.translatable("message.betterinventorysorter.sorted",
                 Component.translatable(method.getTranslationKey()),
@@ -18,6 +66,15 @@ public class SortFeedback {
         displayOverlay(message);
     }
 
+    /**
+     * Displays a feedback message indicating that preferences were changed.
+     *
+     * <p>The message uses the translation key "message.betterinventorysorter.preference_changed"
+     * with the new method and order as parameters.</p>
+     *
+     * @param method the new sort method
+     * @param order the new sort order
+     */
     public static void showPreferenceChange(SortMethod method, SortOrder order) {
         Component message = Component.translatable("message.betterinventorysorter.preference_changed",
                 Component.translatable(method.getTranslationKey()),
@@ -25,11 +82,21 @@ public class SortFeedback {
         displayOverlay(message);
     }
 
+    /**
+     * Sets the overlay message and its expiry time.
+     *
+     * @param message the message to display
+     */
     private static void displayOverlay(Component message) {
         displayMessage = message;
         displayExpiryMs = System.currentTimeMillis() + DISPLAY_DURATION_MS;
     }
 
+    /**
+     * Returns the current display message if it hasn't expired.
+     *
+     * @return the message to display, or null if no message or the message has expired
+     */
     public static Component getDisplayMessage() {
         if (displayMessage != null && System.currentTimeMillis() < displayExpiryMs) {
             return displayMessage;

--- a/src/main/java/xyz/bannach/betterinventorysorter/client/package-info.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/client/package-info.java
@@ -1,0 +1,39 @@
+/**
+ * Client-side logic for the Better Inventory Sorter mod.
+ *
+ * <p>This package contains client-side UI components, event handlers, keybinding management,
+ * and visual feedback systems. All classes in this package are only loaded on the client.</p>
+ *
+ * <h2>Key Components</h2>
+ * <ul>
+ *   <li>{@link xyz.bannach.betterinventorysorter.client.SortButton} - The sort button UI widget
+ *       injected into container screens</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.client.ScreenButtonInjector} - Injects sort buttons
+ *       into supported container screens (chests, shulker boxes, player inventory)</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.client.SortKeyHandler} - Manages keybindings for
+ *       sorting (R key) and preference cycling (P key)</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.client.ClientPreferenceCache} - Caches the player's
+ *       sort preferences locally for UI display</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.client.SortFeedback} - Displays overlay messages
+ *       when sorting or changing preferences</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.client.ClientEvents} - Handles screen events for
+ *       rendering and input processing</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.client.ClientModBusEvents} - Registers keybindings
+ *       on the mod event bus</li>
+ * </ul>
+ *
+ * <h2>Default Keybindings</h2>
+ * <ul>
+ *   <li><strong>R</strong> - Sort the inventory region under the cursor</li>
+ *   <li><strong>P</strong> - Cycle through sort preferences</li>
+ * </ul>
+ *
+ * <h2>Side: Client-only</h2>
+ * <p>All classes use {@link net.neoforged.api.distmarker.Dist#CLIENT} to ensure they are
+ * only loaded on the client side.</p>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.client.SortKeyHandler
+ * @see xyz.bannach.betterinventorysorter.client.SortButton
+ */
+package xyz.bannach.betterinventorysorter.client;

--- a/src/main/java/xyz/bannach/betterinventorysorter/commands/package-info.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/commands/package-info.java
@@ -1,0 +1,36 @@
+/**
+ * Brigadier slash commands for the Better Inventory Sorter mod.
+ *
+ * <p>This package provides the {@code /bis} command tree for controlling inventory sorting
+ * through chat commands. Commands are registered using NeoForge's command registration event.</p>
+ *
+ * <h2>Available Commands</h2>
+ * <ul>
+ *   <li>{@code /bis sortinv [region]} - Sort player inventory (regions: all, main, hotbar)</li>
+ *   <li>{@code /bis change <method> <order>} - Change sort preferences</li>
+ *   <li>{@code /bis reset} - Reset preferences to server defaults</li>
+ *   <li>{@code /bis config [key]} - View current configuration values</li>
+ *   <li>{@code /bis help} - Display help information</li>
+ * </ul>
+ *
+ * <h2>Sort Methods</h2>
+ * <ul>
+ *   <li>{@code alphabetical} - Sort by item name</li>
+ *   <li>{@code category} - Sort by creative tab</li>
+ *   <li>{@code quantity} - Sort by stack count</li>
+ *   <li>{@code mod_id} - Sort by mod namespace</li>
+ * </ul>
+ *
+ * <h2>Sort Orders</h2>
+ * <ul>
+ *   <li>{@code ascending} - Normal sort order</li>
+ *   <li>{@code descending} - Reversed sort order</li>
+ * </ul>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Commands are registered on both client and server, but execute server-side.</p>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.commands.ModCommands
+ */
+package xyz.bannach.betterinventorysorter.commands;

--- a/src/main/java/xyz/bannach/betterinventorysorter/network/CyclePreferencePayload.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/network/CyclePreferencePayload.java
@@ -5,17 +5,48 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+import xyz.bannach.betterinventorysorter.server.PreferenceHandler;
 
+/**
+ * Network payload sent from client to server to cycle sort preferences.
+ *
+ * <p>This payload is sent when the player presses the cycle preference keybind.
+ * It has no data content; the server advances the player's preferences to the
+ * next combination and responds with a {@link SyncPreferencePayload}.</p>
+ *
+ * <h2>Direction</h2>
+ * <p>Client → Server</p>
+ *
+ * <h2>Handling</h2>
+ * <p>Handled by {@link PreferenceHandler#handle(CyclePreferencePayload, net.neoforged.neoforge.network.handling.IPayloadContext)}</p>
+ *
+ * @since 1.0.0
+ * @see PreferenceHandler
+ * @see SyncPreferencePayload
+ * @see xyz.bannach.betterinventorysorter.sorting.SortPreference#next()
+ */
 public record CyclePreferencePayload() implements CustomPacketPayload {
 
+    /**
+     * The payload type identifier for registration and dispatch.
+     */
     public static final Type<CyclePreferencePayload> TYPE = new Type<>(
             ResourceLocation.fromNamespaceAndPath(Betterinventorysorter.MODID, "cycle_preference")
     );
 
+    /**
+     * Codec for encoding and decoding this payload.
+     * <p>Uses a unit codec since this payload carries no data.</p>
+     */
     public static final StreamCodec<ByteBuf, CyclePreferencePayload> STREAM_CODEC = StreamCodec.unit(
             new CyclePreferencePayload()
     );
 
+    /**
+     * Returns the payload type for this packet.
+     *
+     * @return the registered payload type
+     */
     @Override
     public Type<? extends CustomPacketPayload> type() {
         return TYPE;

--- a/src/main/java/xyz/bannach/betterinventorysorter/network/ModPayloads.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/network/ModPayloads.java
@@ -9,9 +9,45 @@ import xyz.bannach.betterinventorysorter.client.ClientPreferenceCache;
 import xyz.bannach.betterinventorysorter.server.PreferenceHandler;
 import xyz.bannach.betterinventorysorter.server.SortHandler;
 
+/**
+ * Registers all network payloads for the mod.
+ *
+ * <p>This class handles the registration of custom packet payloads during the
+ * {@link RegisterPayloadHandlersEvent}. It sets up bidirectional communication
+ * between client and server for sort requests and preference synchronization.</p>
+ *
+ * <h2>Registered Payloads</h2>
+ * <ul>
+ *   <li>{@link SortRequestPayload} - Client → Server: Request to sort an inventory region</li>
+ *   <li>{@link CyclePreferencePayload} - Client → Server: Request to cycle sort preferences</li>
+ *   <li>{@link SyncPreferencePayload} - Server → Client: Sync current preferences to client</li>
+ * </ul>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Registration occurs on both sides during the network setup phase.</p>
+ *
+ * @since 1.0.0
+ * @see SortRequestPayload
+ * @see CyclePreferencePayload
+ * @see SyncPreferencePayload
+ */
 @EventBusSubscriber(modid = Betterinventorysorter.MODID)
 public class ModPayloads {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private ModPayloads() {}
+
+    /**
+     * Registers all mod network payloads.
+     *
+     * <p>This method is called during network initialization and registers handlers
+     * for all custom packets used by the mod. The protocol version "1" ensures
+     * compatibility checking between client and server.</p>
+     *
+     * @param event the payload registration event
+     */
     @SubscribeEvent
     public static void register(RegisterPayloadHandlersEvent event) {
         PayloadRegistrar registrar = event.registrar("1");

--- a/src/main/java/xyz/bannach/betterinventorysorter/network/SortRequestPayload.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/network/SortRequestPayload.java
@@ -6,18 +6,49 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+import xyz.bannach.betterinventorysorter.server.SortHandler;
 
+/**
+ * Network payload sent from client to server to request inventory sorting.
+ *
+ * <p>This payload is sent when the player triggers a sort action via keybind
+ * or button click. It contains the region identifier specifying which inventory
+ * area to sort.</p>
+ *
+ * <h2>Direction</h2>
+ * <p>Client → Server</p>
+ *
+ * <h2>Handling</h2>
+ * <p>Handled by {@link SortHandler#handle(SortRequestPayload, net.neoforged.neoforge.network.handling.IPayloadContext)}</p>
+ *
+ * @param region the inventory region to sort (see {@link SortHandler} for region constants)
+ * @since 1.0.0
+ * @see SortHandler#REGION_CONTAINER
+ * @see SortHandler#REGION_PLAYER_MAIN
+ * @see SortHandler#REGION_PLAYER_HOTBAR
+ */
 public record SortRequestPayload(int region) implements CustomPacketPayload {
 
+    /**
+     * The payload type identifier for registration and dispatch.
+     */
     public static final Type<SortRequestPayload> TYPE = new Type<>(
             ResourceLocation.fromNamespaceAndPath(Betterinventorysorter.MODID, "sort_request")
     );
 
+    /**
+     * Codec for encoding and decoding this payload to/from a byte buffer.
+     */
     public static final StreamCodec<ByteBuf, SortRequestPayload> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.VAR_INT, SortRequestPayload::region,
             SortRequestPayload::new
     );
 
+    /**
+     * Returns the payload type for this packet.
+     *
+     * @return the registered payload type
+     */
     @Override
     public Type<? extends CustomPacketPayload> type() {
         return TYPE;

--- a/src/main/java/xyz/bannach/betterinventorysorter/network/SyncPreferencePayload.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/network/SyncPreferencePayload.java
@@ -6,15 +6,43 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import xyz.bannach.betterinventorysorter.Betterinventorysorter;
+import xyz.bannach.betterinventorysorter.client.ClientPreferenceCache;
 import xyz.bannach.betterinventorysorter.sorting.SortMethod;
 import xyz.bannach.betterinventorysorter.sorting.SortOrder;
 
+/**
+ * Network payload sent from server to client to synchronize sort preferences.
+ *
+ * <p>This payload is sent when the player logs in or when their preferences change
+ * on the server. It contains the current sort method and order that the client
+ * should display in the UI.</p>
+ *
+ * <h2>Direction</h2>
+ * <p>Server → Client</p>
+ *
+ * <h2>Handling</h2>
+ * <p>Handled by {@link ClientPreferenceCache#handle(SyncPreferencePayload, net.neoforged.neoforge.network.handling.IPayloadContext)}</p>
+ *
+ * @param method the player's current sort method
+ * @param order the player's current sort order
+ * @since 1.0.0
+ * @see SortMethod
+ * @see SortOrder
+ * @see ClientPreferenceCache
+ */
 public record SyncPreferencePayload(SortMethod method, SortOrder order) implements CustomPacketPayload {
 
+    /**
+     * The payload type identifier for registration and dispatch.
+     */
     public static final Type<SyncPreferencePayload> TYPE = new Type<>(
             ResourceLocation.fromNamespaceAndPath(Betterinventorysorter.MODID, "sync_preference")
     );
 
+    /**
+     * Codec for encoding and decoding this payload to/from a byte buffer.
+     * <p>Encodes enums as their serialized string names for readability and stability.</p>
+     */
     public static final StreamCodec<ByteBuf, SyncPreferencePayload> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.STRING_UTF8.map(
                     SyncPreferencePayload::methodFromName,
@@ -27,11 +55,22 @@ public record SyncPreferencePayload(SortMethod method, SortOrder order) implemen
             SyncPreferencePayload::new
     );
 
+    /**
+     * Returns the payload type for this packet.
+     *
+     * @return the registered payload type
+     */
     @Override
     public Type<? extends CustomPacketPayload> type() {
         return TYPE;
     }
 
+    /**
+     * Parses a SortMethod from its serialized name.
+     *
+     * @param name the serialized name to parse
+     * @return the matching SortMethod, or {@link SortMethod#ALPHABETICAL} if not found
+     */
     private static SortMethod methodFromName(String name) {
         for (SortMethod m : SortMethod.values()) {
             if (m.getSerializedName().equals(name)) {
@@ -41,6 +80,12 @@ public record SyncPreferencePayload(SortMethod method, SortOrder order) implemen
         return SortMethod.ALPHABETICAL;
     }
 
+    /**
+     * Parses a SortOrder from its serialized name.
+     *
+     * @param name the serialized name to parse
+     * @return the matching SortOrder, or {@link SortOrder#ASCENDING} if not found
+     */
     private static SortOrder orderFromName(String name) {
         for (SortOrder o : SortOrder.values()) {
             if (o.getSerializedName().equals(name)) {

--- a/src/main/java/xyz/bannach/betterinventorysorter/network/package-info.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/network/package-info.java
@@ -1,0 +1,28 @@
+/**
+ * Network payloads for client-server communication.
+ *
+ * <p>This package defines the custom packet payloads used for communication between
+ * the client and server. All payloads implement {@link net.minecraft.network.protocol.common.custom.CustomPacketPayload}
+ * and use NeoForge's payload registration system.</p>
+ *
+ * <h2>Payload Types</h2>
+ * <ul>
+ *   <li>{@link xyz.bannach.betterinventorysorter.network.SortRequestPayload} - Client-to-server request
+ *       to sort a specific inventory region</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.network.CyclePreferencePayload} - Client-to-server request
+ *       to cycle the player's sort preferences</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.network.SyncPreferencePayload} - Server-to-client sync
+ *       of the player's current sort preferences</li>
+ * </ul>
+ *
+ * <h2>Registration</h2>
+ * <p>All payloads are registered in {@link xyz.bannach.betterinventorysorter.network.ModPayloads}
+ * during the {@link net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent}.</p>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Network payloads are loaded on both client and server sides.</p>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.network.ModPayloads
+ */
+package xyz.bannach.betterinventorysorter.network;

--- a/src/main/java/xyz/bannach/betterinventorysorter/package-info.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/package-info.java
@@ -1,0 +1,28 @@
+/**
+ * Root package for the Better Inventory Sorter mod.
+ *
+ * <p>This NeoForge mod for Minecraft 1.21.1 provides enhanced inventory sorting capabilities
+ * with configurable sort methods and orders. The mod supports sorting player inventories
+ * and container inventories (chests, shulker boxes, etc.) using various sorting strategies.</p>
+ *
+ * <h2>Package Structure</h2>
+ * <ul>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting} - Core sorting logic and comparators</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.network} - Network payloads for client-server communication</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.server} - Server-side event handlers and sort processing</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.client} - Client-side UI, keybindings, and feedback</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.commands} - Brigadier slash commands</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.test} - NeoForge GameTest framework tests</li>
+ * </ul>
+ *
+ * <h2>Key Classes</h2>
+ * <ul>
+ *   <li>{@link xyz.bannach.betterinventorysorter.Betterinventorysorter} - Main mod entrypoint</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.Config} - Mod configuration (client and server)</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.ModAttachments} - Player data attachments for sort preferences</li>
+ * </ul>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.Betterinventorysorter
+ */
+package xyz.bannach.betterinventorysorter;

--- a/src/main/java/xyz/bannach/betterinventorysorter/server/PreferenceHandler.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/server/PreferenceHandler.java
@@ -8,8 +8,44 @@ import xyz.bannach.betterinventorysorter.network.CyclePreferencePayload;
 import xyz.bannach.betterinventorysorter.network.SyncPreferencePayload;
 import xyz.bannach.betterinventorysorter.sorting.SortPreference;
 
+/**
+ * Server-side handler for preference cycling requests.
+ *
+ * <p>This class processes incoming cycle preference requests from clients,
+ * advances the player's sort preferences to the next combination, persists
+ * the change, and synchronizes the new preferences back to the client.</p>
+ *
+ * <h2>Cycling Pattern</h2>
+ * <p>Preferences cycle through all combinations of method and order:</p>
+ * <pre>
+ * Alphabetical(Asc) → Alphabetical(Desc) → Category(Asc) → Category(Desc) → ...
+ * </pre>
+ *
+ * <h2>Side: Server-only</h2>
+ * <p>Preferences are stored server-side and synced to clients.</p>
+ *
+ * @since 1.0.0
+ * @see CyclePreferencePayload
+ * @see SyncPreferencePayload
+ * @see SortPreference#next()
+ */
 public class PreferenceHandler {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private PreferenceHandler() {}
+
+    /**
+     * Handles an incoming cycle preference request from a client.
+     *
+     * <p>This method retrieves the player's current preferences, advances to the
+     * next combination, saves the new preferences, and sends a sync packet to
+     * update the client's cache.</p>
+     *
+     * @param payload the cycle preference payload (contains no data)
+     * @param context the network context containing the sending player
+     */
     public static void handle(CyclePreferencePayload payload, IPayloadContext context) {
         context.enqueueWork(() -> {
             ServerPlayer player = (ServerPlayer) context.player();

--- a/src/main/java/xyz/bannach/betterinventorysorter/server/ServerEvents.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/server/ServerEvents.java
@@ -10,9 +10,41 @@ import xyz.bannach.betterinventorysorter.ModAttachments;
 import xyz.bannach.betterinventorysorter.network.SyncPreferencePayload;
 import xyz.bannach.betterinventorysorter.sorting.SortPreference;
 
+/**
+ * Server-side event listeners for the mod.
+ *
+ * <p>This class handles server-side events that require mod interaction,
+ * such as synchronizing player preferences when they log in.</p>
+ *
+ * <h2>Handled Events</h2>
+ * <ul>
+ *   <li>{@link PlayerEvent.PlayerLoggedInEvent} - Sync preferences on player login</li>
+ * </ul>
+ *
+ * <h2>Side: Server-only</h2>
+ * <p>These events only fire on the server (or integrated server for singleplayer).</p>
+ *
+ * @since 1.0.0
+ * @see SyncPreferencePayload
+ * @see ModAttachments#SORT_PREFERENCE
+ */
 @EventBusSubscriber(modid = Betterinventorysorter.MODID)
 public class ServerEvents {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private ServerEvents() {}
+
+    /**
+     * Handles player login events by synchronizing their sort preferences.
+     *
+     * <p>When a player logs in, their stored sort preferences are read from the
+     * player data attachment and sent to the client via a {@link SyncPreferencePayload}.
+     * This ensures the client's preference cache is up-to-date for UI display.</p>
+     *
+     * @param event the player login event
+     */
     @SubscribeEvent
     public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         if (event.getEntity() instanceof ServerPlayer player) {

--- a/src/main/java/xyz/bannach/betterinventorysorter/server/SortHandler.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/server/SortHandler.java
@@ -18,12 +18,77 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Server-side handler for sort request payloads.
+ *
+ * <p>This class processes incoming sort requests from clients, determines which
+ * inventory slots to sort based on the requested region, and performs the sorting
+ * operation using the player's stored preferences.</p>
+ *
+ * <h2>Inventory Regions</h2>
+ * <ul>
+ *   <li>{@link #REGION_CONTAINER} (0) - Container inventory (chest, shulker box, etc.)</li>
+ *   <li>{@link #REGION_PLAYER_MAIN} (1) - Player's main inventory (slots 9-35)</li>
+ *   <li>{@link #REGION_PLAYER_HOTBAR} (2) - Player's hotbar (slots 0-8)</li>
+ * </ul>
+ *
+ * <h2>Slot Filtering</h2>
+ * <p>The handler intelligently filters out non-sortable slots:</p>
+ * <ul>
+ *   <li>Special slot subclasses (result slots, fuel slots, armor slots)</li>
+ *   <li>Crafting grid slots</li>
+ *   <li>Containers that contain any special slots (e.g., furnace)</li>
+ * </ul>
+ *
+ * <h2>Side: Server-only</h2>
+ * <p>All sorting operations execute on the server to prevent cheating.</p>
+ *
+ * @since 1.0.0
+ * @see SortRequestPayload
+ * @see ItemSorter
+ */
 public class SortHandler {
 
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private SortHandler() {}
+
+    /**
+     * Region code for the container's inventory (chest, shulker box, etc.).
+     * <p>Value: {@value}</p>
+     */
     public static final int REGION_CONTAINER = 0;
+
+    /**
+     * Region code for the player's main inventory (slots 9-35, excluding hotbar).
+     * <p>Value: {@value}</p>
+     */
     public static final int REGION_PLAYER_MAIN = 1;
+
+    /**
+     * Region code for the player's hotbar (slots 0-8).
+     * <p>Value: {@value}</p>
+     */
     public static final int REGION_PLAYER_HOTBAR = 2;
 
+    /**
+     * Handles an incoming sort request from a client.
+     *
+     * <p>This method validates the request, determines target slots, extracts items,
+     * sorts them using the player's preferences, and writes the sorted items back
+     * to the slots. The operation is enqueued on the main server thread.</p>
+     *
+     * <p><strong>Guard Conditions:</strong></p>
+     * <ul>
+     *   <li>Spectator mode players are ignored</li>
+     *   <li>Container region requests are ignored when no container is open</li>
+     *   <li>Empty target slot lists result in no-op</li>
+     * </ul>
+     *
+     * @param payload the sort request containing the target region
+     * @param context the network context containing the sending player
+     */
     public static void handle(SortRequestPayload payload, IPayloadContext context) {
         context.enqueueWork(() -> {
             ServerPlayer player = (ServerPlayer) context.player();
@@ -56,6 +121,22 @@ public class SortHandler {
         });
     }
 
+    /**
+     * Determines which slots in a menu belong to the specified region.
+     *
+     * <p>This method filters menu slots based on the region code and excludes
+     * non-sortable slots such as:</p>
+     * <ul>
+     *   <li>Special slot subclasses (ResultSlot, FurnaceFuelSlot, etc.)</li>
+     *   <li>Crafting container slots</li>
+     *   <li>Any container that contains special slots (to avoid sorting furnace inputs)</li>
+     *   <li>Armor and offhand slots (outside slots 0-35)</li>
+     * </ul>
+     *
+     * @param menu the container menu to analyze
+     * @param region the region code ({@link #REGION_CONTAINER}, {@link #REGION_PLAYER_MAIN}, or {@link #REGION_PLAYER_HOTBAR})
+     * @return a list of sortable slots for the specified region, may be empty
+     */
     public static List<Slot> getTargetSlots(AbstractContainerMenu menu, int region) {
         // For REGION_CONTAINER, build a set of containers that have any special slot subclass.
         // A base Slot sharing a container with a subclass (e.g. furnace ingredient slot) is not sortable.

--- a/src/main/java/xyz/bannach/betterinventorysorter/server/package-info.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/server/package-info.java
@@ -1,0 +1,33 @@
+/**
+ * Server-side logic for the Better Inventory Sorter mod.
+ *
+ * <p>This package contains server-side event handlers and payload processors that
+ * handle sort requests, preference cycling, and player login synchronization.</p>
+ *
+ * <h2>Key Components</h2>
+ * <ul>
+ *   <li>{@link xyz.bannach.betterinventorysorter.server.SortHandler} - Processes sort requests,
+ *       determines target slots, and executes the sorting operation</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.server.PreferenceHandler} - Handles preference
+ *       cycling requests and syncs updated preferences to the client</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.server.ServerEvents} - Listens for player login
+ *       events to sync preferences on join</li>
+ * </ul>
+ *
+ * <h2>Inventory Regions</h2>
+ * <p>The server supports three distinct sorting regions defined in {@link xyz.bannach.betterinventorysorter.server.SortHandler}:</p>
+ * <ul>
+ *   <li>{@code REGION_CONTAINER} (0) - The container's inventory (chest, shulker box, etc.)</li>
+ *   <li>{@code REGION_PLAYER_MAIN} (1) - Player's main inventory (slots 9-35)</li>
+ *   <li>{@code REGION_PLAYER_HOTBAR} (2) - Player's hotbar (slots 0-8)</li>
+ * </ul>
+ *
+ * <h2>Side: Server-only</h2>
+ * <p>All sorting operations are performed server-side to ensure data integrity and
+ * prevent client-side manipulation.</p>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.server.SortHandler
+ * @see xyz.bannach.betterinventorysorter.sorting.ItemSorter
+ */
+package xyz.bannach.betterinventorysorter.server;

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/ItemSorter.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/ItemSorter.java
@@ -11,10 +11,53 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+/**
+ * Core utility class for sorting inventory item stacks.
+ *
+ * <p>This class provides the main sorting pipeline that handles stack merging,
+ * sorting, and slot padding. It is designed to be stateless with all methods
+ * being static.</p>
+ *
+ * <h2>Sorting Pipeline</h2>
+ * <ol>
+ *   <li>Condense partial stacks into full stacks where possible</li>
+ *   <li>Filter out empty slots</li>
+ *   <li>Sort non-empty items using the appropriate comparator</li>
+ *   <li>Reverse if descending order is selected</li>
+ *   <li>Pad with empty stacks to preserve original slot count</li>
+ * </ol>
+ *
+ * <h2>Side: Common</h2>
+ * <p>This class is used primarily server-side for actual sorting, but the logic
+ * is available on both sides.</p>
+ *
+ * @since 1.0.0
+ * @see SortPreference
+ * @see xyz.bannach.betterinventorysorter.sorting.comparator
+ */
 public final class ItemSorter {
 
+    /**
+     * Private constructor to prevent instantiation.
+     */
     private ItemSorter() {}
 
+    /**
+     * Sorts a list of item stacks according to the given preferences.
+     *
+     * <p>The sorting process:</p>
+     * <ol>
+     *   <li>Merges partial stacks of the same item type</li>
+     *   <li>Removes empty stacks from consideration</li>
+     *   <li>Sorts remaining items using the preference's method</li>
+     *   <li>Reverses order if preference specifies descending</li>
+     *   <li>Pads with empty stacks to match original size</li>
+     * </ol>
+     *
+     * @param stacks the list of item stacks to sort (not modified)
+     * @param preference the sorting preferences containing method and order
+     * @return a new list containing the sorted stacks with preserved slot count
+     */
     public static List<ItemStack> sort(List<ItemStack> stacks, SortPreference preference) {
         int originalSize = stacks.size();
 
@@ -46,6 +89,18 @@ public final class ItemSorter {
         return items;
     }
 
+    /**
+     * Merges partial stacks of the same item type into full stacks.
+     *
+     * <p>This method combines stacks that share the same item and components,
+     * respecting each item's maximum stack size. Items that cannot be stacked
+     * (different items, different NBT, or max stack size of 1) remain separate.</p>
+     *
+     * <p>Example: Two stacks of 32 Stone become one stack of 64 Stone.</p>
+     *
+     * @param stacks the list of item stacks to merge (not modified)
+     * @return a new list containing merged stacks (empty stacks are excluded)
+     */
     public static List<ItemStack> mergeStacks(List<ItemStack> stacks) {
         List<ItemStack> result = new ArrayList<>();
 
@@ -80,6 +135,12 @@ public final class ItemSorter {
         return result;
     }
 
+    /**
+     * Returns the appropriate comparator for the given sort method.
+     *
+     * @param method the sort method to get a comparator for
+     * @return the singleton comparator instance for the specified method
+     */
     private static Comparator<ItemStack> getComparator(SortMethod method) {
         return switch (method) {
             case ALPHABETICAL -> AlphabeticalComparator.INSTANCE;

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortMethod.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortMethod.java
@@ -2,30 +2,97 @@ package xyz.bannach.betterinventorysorter.sorting;
 
 import net.minecraft.util.StringRepresentable;
 
+/**
+ * Enumeration of available sorting methods for inventory items.
+ *
+ * <p>Each sort method corresponds to a different {@link java.util.Comparator} implementation
+ * in the {@link xyz.bannach.betterinventorysorter.sorting.comparator} package.</p>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Used on both client and server for preference storage and sorting operations.</p>
+ *
+ * @since 1.0.0
+ * @see SortOrder
+ * @see SortPreference
+ * @see ItemSorter
+ */
 public enum SortMethod implements StringRepresentable {
+
+    /**
+     * Sort items alphabetically by their display name (case-insensitive).
+     *
+     * @see xyz.bannach.betterinventorysorter.sorting.comparator.AlphabeticalComparator
+     */
     ALPHABETICAL("alphabetical"),
+
+    /**
+     * Sort items by their creative mode tab category, then alphabetically within each category.
+     *
+     * @see xyz.bannach.betterinventorysorter.sorting.comparator.CategoryComparator
+     */
     CATEGORY("category"),
+
+    /**
+     * Sort items by stack quantity (highest first), then alphabetically for equal quantities.
+     *
+     * @see xyz.bannach.betterinventorysorter.sorting.comparator.QuantityComparator
+     */
     QUANTITY("quantity"),
+
+    /**
+     * Sort items by their mod namespace (mod ID), then alphabetically within each mod.
+     *
+     * @see xyz.bannach.betterinventorysorter.sorting.comparator.ModIdComparator
+     */
     MOD_ID("mod_id");
 
+    /**
+     * Codec for serializing and deserializing SortMethod values.
+     * <p>Used for NBT persistence and network communication.</p>
+     */
     public static final com.mojang.serialization.Codec<SortMethod> CODEC = StringRepresentable.fromEnum(SortMethod::values);
 
+    /**
+     * The string representation used for serialization and translation keys.
+     */
     private final String serializedName;
 
+    /**
+     * Constructs a SortMethod with the given serialized name.
+     *
+     * @param serializedName the string identifier for this sort method
+     */
     SortMethod(String serializedName) {
         this.serializedName = serializedName;
     }
 
+    /**
+     * Returns the serialized name of this sort method.
+     *
+     * @return the string identifier for this sort method
+     */
     @Override
     public String getSerializedName() {
         return serializedName;
     }
 
+    /**
+     * Returns the next sort method in the cycle.
+     *
+     * <p>The cycle order is: ALPHABETICAL → CATEGORY → QUANTITY → MOD_ID → ALPHABETICAL</p>
+     *
+     * @return the next sort method in the enumeration order, wrapping to the first after the last
+     */
     public SortMethod next() {
         SortMethod[] values = values();
         return values[(ordinal() + 1) % values.length];
     }
 
+    /**
+     * Returns the translation key for this sort method's display name.
+     *
+     * @return the translation key in the format "sort_method.betterinventorysorter.{name}"
+     */
     public String getTranslationKey() {
         return "sort_method.betterinventorysorter." + serializedName;
     }

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortOrder.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortOrder.java
@@ -2,27 +2,76 @@ package xyz.bannach.betterinventorysorter.sorting;
 
 import net.minecraft.util.StringRepresentable;
 
+/**
+ * Enumeration of available sort directions.
+ *
+ * <p>Sort order determines whether items are arranged in normal order (ascending)
+ * or reversed order (descending) after sorting.</p>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Used on both client and server for preference storage and sorting operations.</p>
+ *
+ * @since 1.0.0
+ * @see SortMethod
+ * @see SortPreference
+ * @see ItemSorter
+ */
 public enum SortOrder implements StringRepresentable {
+
+    /**
+     * Normal sort order (A-Z, lowest to highest, etc.).
+     */
     ASCENDING("ascending"),
+
+    /**
+     * Reversed sort order (Z-A, highest to lowest, etc.).
+     */
     DESCENDING("descending");
 
+    /**
+     * Codec for serializing and deserializing SortOrder values.
+     * <p>Used for NBT persistence and network communication.</p>
+     */
     public static final com.mojang.serialization.Codec<SortOrder> CODEC = StringRepresentable.fromEnum(SortOrder::values);
 
+    /**
+     * The string representation used for serialization and translation keys.
+     */
     private final String serializedName;
 
+    /**
+     * Constructs a SortOrder with the given serialized name.
+     *
+     * @param serializedName the string identifier for this sort order
+     */
     SortOrder(String serializedName) {
         this.serializedName = serializedName;
     }
 
+    /**
+     * Returns the serialized name of this sort order.
+     *
+     * @return the string identifier for this sort order
+     */
     @Override
     public String getSerializedName() {
         return serializedName;
     }
 
+    /**
+     * Returns the opposite sort order.
+     *
+     * @return {@link #DESCENDING} if this is {@link #ASCENDING}, or {@link #ASCENDING} if this is {@link #DESCENDING}
+     */
     public SortOrder toggle() {
         return this == ASCENDING ? DESCENDING : ASCENDING;
     }
 
+    /**
+     * Returns the translation key for this sort order's display name.
+     *
+     * @return the translation key in the format "sort_order.betterinventorysorter.{name}"
+     */
     public String getTranslationKey() {
         return "sort_order.betterinventorysorter." + serializedName;
     }

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortPreference.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/SortPreference.java
@@ -3,27 +3,73 @@ package xyz.bannach.betterinventorysorter.sorting;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
+/**
+ * Immutable record holding a player's sort preferences.
+ *
+ * <p>A SortPreference combines a {@link SortMethod} and {@link SortOrder} to define
+ * how items should be sorted. Instances are immutable; modification methods return
+ * new instances with the updated values.</p>
+ *
+ * <h2>Persistence</h2>
+ * <p>Sort preferences are persisted using the {@link #CODEC} for NBT serialization
+ * and attached to players via {@link xyz.bannach.betterinventorysorter.ModAttachments#SORT_PREFERENCE}.</p>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Used on both client and server for preference storage and sorting operations.</p>
+ *
+ * @param method the sort method to use (alphabetical, category, quantity, or mod_id)
+ * @param order the sort direction (ascending or descending)
+ * @since 1.0.0
+ * @see SortMethod
+ * @see SortOrder
+ * @see ItemSorter
+ */
 public record SortPreference(SortMethod method, SortOrder order) {
 
+    /**
+     * The default sort preference: {@link SortMethod#ALPHABETICAL} with {@link SortOrder#ASCENDING}.
+     */
     public static final SortPreference DEFAULT = new SortPreference(SortMethod.ALPHABETICAL, SortOrder.ASCENDING);
 
+    /**
+     * Codec for serializing and deserializing SortPreference to/from NBT.
+     * <p>Used by {@link xyz.bannach.betterinventorysorter.ModAttachments} for player data persistence.</p>
+     */
     public static final Codec<SortPreference> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             SortMethod.CODEC.fieldOf("method").forGetter(SortPreference::method),
             SortOrder.CODEC.fieldOf("order").forGetter(SortPreference::order)
     ).apply(instance, SortPreference::new));
 
+    /**
+     * Returns a new preference with the next sort method, keeping the current order.
+     *
+     * @return a new SortPreference with the next method in the cycle
+     * @see SortMethod#next()
+     */
     public SortPreference withNextMethod() {
         return new SortPreference(method.next(), order);
     }
 
+    /**
+     * Returns a new preference with the toggled sort order, keeping the current method.
+     *
+     * @return a new SortPreference with the opposite order
+     * @see SortOrder#toggle()
+     */
     public SortPreference withToggledOrder() {
         return new SortPreference(method, order.toggle());
     }
 
     /**
      * Cycles to the next preference combination.
-     * Pattern: Toggle order first, then advance method when wrapping from DESCENDING to ASCENDING.
-     * This creates the sequence: Alphabetical(Asc) -> Alphabetical(Desc) -> Category(Asc) -> ...
+     *
+     * <p>The cycling pattern toggles order first, then advances method when wrapping
+     * from DESCENDING to ASCENDING. This creates the sequence:</p>
+     * <pre>
+     * Alphabetical(Asc) → Alphabetical(Desc) → Category(Asc) → Category(Desc) → ...
+     * </pre>
+     *
+     * @return a new SortPreference representing the next combination in the cycle
      */
     public SortPreference next() {
         SortOrder nextOrder = this.order.toggle();

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/AlphabeticalComparator.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/AlphabeticalComparator.java
@@ -4,10 +4,49 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.Comparator;
 
+/**
+ * Comparator that sorts item stacks alphabetically by their display name.
+ *
+ * <p>This comparator uses case-insensitive string comparison on the item's
+ * hover name (display name). It serves as both a primary comparator for
+ * alphabetical sorting and as a tiebreaker for other comparators.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * items.sort(AlphabeticalComparator.INSTANCE);
+ * }</pre>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Can be used on both client and server.</p>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.sorting.SortMethod#ALPHABETICAL
+ * @see xyz.bannach.betterinventorysorter.sorting.ItemSorter
+ */
 public class AlphabeticalComparator implements Comparator<ItemStack> {
 
+    /**
+     * Singleton instance of this comparator.
+     */
     public static final AlphabeticalComparator INSTANCE = new AlphabeticalComparator();
 
+    /**
+     * Private constructor to enforce singleton pattern.
+     * Use {@link #INSTANCE} to access this comparator.
+     */
+    private AlphabeticalComparator() {}
+
+    /**
+     * Compares two item stacks by their display names.
+     *
+     * <p>Comparison is case-insensitive and based on the localized display name
+     * returned by {@link ItemStack#getHoverName()}.</p>
+     *
+     * @param a the first item stack to compare
+     * @param b the second item stack to compare
+     * @return a negative integer, zero, or a positive integer if the first item's
+     *         name is alphabetically less than, equal to, or greater than the second
+     */
     @Override
     public int compare(ItemStack a, ItemStack b) {
         return String.CASE_INSENSITIVE_ORDER.compare(

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/CategoryComparator.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/CategoryComparator.java
@@ -6,12 +6,62 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.Comparator;
 
+/**
+ * Comparator that sorts item stacks by their creative mode tab category.
+ *
+ * <p>Items are grouped by the creative mode tab they belong to, with items
+ * in earlier tabs sorting before items in later tabs. Items within the same
+ * tab are sorted alphabetically. Uncategorized items (not in any tab) sort
+ * last, ordered by their registry ID.</p>
+ *
+ * <h2>Sort Order</h2>
+ * <ol>
+ *   <li>Items are grouped by creative tab index (registration order)</li>
+ *   <li>Within each tab, items are sorted alphabetically by name</li>
+ *   <li>Items not in any tab sort last, by registry ID</li>
+ * </ol>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * items.sort(CategoryComparator.INSTANCE);
+ * }</pre>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Can be used on both client and server.</p>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.sorting.SortMethod#CATEGORY
+ * @see xyz.bannach.betterinventorysorter.sorting.ItemSorter
+ */
 public class CategoryComparator implements Comparator<ItemStack> {
 
+    /**
+     * Singleton instance of this comparator.
+     */
     public static final CategoryComparator INSTANCE = new CategoryComparator();
 
+    /**
+     * Offset added to registry IDs for uncategorized items to ensure they sort last.
+     */
     private static final int UNCATEGORIZED_OFFSET = 1_000_000;
 
+    /**
+     * Private constructor to enforce singleton pattern.
+     * Use {@link #INSTANCE} to access this comparator.
+     */
+    private CategoryComparator() {}
+
+    /**
+     * Compares two item stacks by their creative tab category.
+     *
+     * <p>Items are first compared by their creative tab index. If both items
+     * are in the same tab (or both uncategorized), they are compared alphabetically.</p>
+     *
+     * @param a the first item stack to compare
+     * @param b the second item stack to compare
+     * @return a negative integer, zero, or a positive integer if the first item
+     *         should sort before, equal to, or after the second
+     */
     @Override
     public int compare(ItemStack a, ItemStack b) {
         int indexA = getTabIndex(a);
@@ -23,6 +73,16 @@ public class CategoryComparator implements Comparator<ItemStack> {
         return AlphabeticalComparator.INSTANCE.compare(a, b);
     }
 
+    /**
+     * Gets the sorting index for an item based on its creative tab.
+     *
+     * <p>Items in creative tabs return the tab's index (0-based). Items not in
+     * any tab return {@link #UNCATEGORIZED_OFFSET} plus their registry ID to
+     * ensure consistent ordering.</p>
+     *
+     * @param stack the item stack to get the tab index for
+     * @return the tab index, or a large value for uncategorized items
+     */
     private static int getTabIndex(ItemStack stack) {
         var tabs = CreativeModeTabs.allTabs();
         for (int i = 0; i < tabs.size(); i++) {

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/ModIdComparator.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/ModIdComparator.java
@@ -5,10 +5,56 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.Comparator;
 
+/**
+ * Comparator that sorts item stacks by their mod namespace (mod ID).
+ *
+ * <p>Items are grouped by the mod that registered them, with vanilla Minecraft
+ * items (namespace "minecraft") typically sorting first. Items from the same
+ * mod are sorted alphabetically by their display name.</p>
+ *
+ * <h2>Sort Order</h2>
+ * <ol>
+ *   <li>Items are grouped by mod namespace (case-insensitive)</li>
+ *   <li>Within each mod, items are sorted alphabetically by name</li>
+ * </ol>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * items.sort(ModIdComparator.INSTANCE);
+ * }</pre>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Can be used on both client and server.</p>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.sorting.SortMethod#MOD_ID
+ * @see xyz.bannach.betterinventorysorter.sorting.ItemSorter
+ */
 public class ModIdComparator implements Comparator<ItemStack> {
 
+    /**
+     * Singleton instance of this comparator.
+     */
     public static final ModIdComparator INSTANCE = new ModIdComparator();
 
+    /**
+     * Private constructor to enforce singleton pattern.
+     * Use {@link #INSTANCE} to access this comparator.
+     */
+    private ModIdComparator() {}
+
+    /**
+     * Compares two item stacks by their mod namespace.
+     *
+     * <p>Items are first compared by their registry namespace (mod ID) using
+     * case-insensitive comparison. If both items are from the same mod, they
+     * are compared alphabetically by display name.</p>
+     *
+     * @param a the first item stack to compare
+     * @param b the second item stack to compare
+     * @return a negative integer, zero, or a positive integer if the first item
+     *         should sort before, equal to, or after the second
+     */
     @Override
     public int compare(ItemStack a, ItemStack b) {
         String nsA = BuiltInRegistries.ITEM.getKey(a.getItem()).getNamespace();

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/QuantityComparator.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/QuantityComparator.java
@@ -4,10 +4,58 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.Comparator;
 
+/**
+ * Comparator that sorts item stacks by their quantity (stack count).
+ *
+ * <p>Items with higher quantities sort first (descending by count). Items
+ * with equal quantities are sorted alphabetically by their display name.</p>
+ *
+ * <h2>Sort Order</h2>
+ * <ol>
+ *   <li>Items are sorted by count in descending order (highest first)</li>
+ *   <li>Items with equal counts are sorted alphabetically by name</li>
+ * </ol>
+ *
+ * <h2>Note</h2>
+ * <p>The default ascending order for this comparator places highest quantities
+ * first. Using descending order will place lowest quantities first.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * items.sort(QuantityComparator.INSTANCE);
+ * }</pre>
+ *
+ * <h2>Side: Common</h2>
+ * <p>Can be used on both client and server.</p>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.sorting.SortMethod#QUANTITY
+ * @see xyz.bannach.betterinventorysorter.sorting.ItemSorter
+ */
 public class QuantityComparator implements Comparator<ItemStack> {
 
+    /**
+     * Singleton instance of this comparator.
+     */
     public static final QuantityComparator INSTANCE = new QuantityComparator();
 
+    /**
+     * Private constructor to enforce singleton pattern.
+     * Use {@link #INSTANCE} to access this comparator.
+     */
+    private QuantityComparator() {}
+
+    /**
+     * Compares two item stacks by their quantity.
+     *
+     * <p>Items are compared by count in descending order (higher counts first).
+     * If both items have the same count, they are compared alphabetically.</p>
+     *
+     * @param a the first item stack to compare
+     * @param b the second item stack to compare
+     * @return a negative integer, zero, or a positive integer if the first item
+     *         should sort before, equal to, or after the second
+     */
     @Override
     public int compare(ItemStack a, ItemStack b) {
         int result = Integer.compare(b.getCount(), a.getCount());

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/package-info.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/comparator/package-info.java
@@ -1,0 +1,31 @@
+/**
+ * ItemStack comparators for different sorting strategies.
+ *
+ * <p>This package provides singleton comparator implementations for each sort method
+ * supported by the mod. All comparators use alphabetical comparison as a tiebreaker
+ * to ensure consistent, stable sort results.</p>
+ *
+ * <h2>Available Comparators</h2>
+ * <ul>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting.comparator.AlphabeticalComparator} -
+ *       Sorts items by their display name (case-insensitive)</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting.comparator.CategoryComparator} -
+ *       Groups items by creative mode tab, then alphabetically within each group</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting.comparator.QuantityComparator} -
+ *       Sorts by stack count (highest first), then alphabetically</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting.comparator.ModIdComparator} -
+ *       Groups items by mod namespace, then alphabetically within each group</li>
+ * </ul>
+ *
+ * <h2>Usage Pattern</h2>
+ * <p>All comparators are singletons accessed via their {@code INSTANCE} field:</p>
+ * <pre>{@code
+ * Comparator<ItemStack> comparator = AlphabeticalComparator.INSTANCE;
+ * items.sort(comparator);
+ * }</pre>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.sorting.ItemSorter
+ * @see xyz.bannach.betterinventorysorter.sorting.SortMethod
+ */
+package xyz.bannach.betterinventorysorter.sorting.comparator;

--- a/src/main/java/xyz/bannach/betterinventorysorter/sorting/package-info.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/sorting/package-info.java
@@ -1,0 +1,32 @@
+/**
+ * Core sorting logic for the Better Inventory Sorter mod.
+ *
+ * <p>This package contains the sorting engine, preference management, and sort method/order enums.
+ * The sorting system supports multiple sort strategies with ascending/descending order options.</p>
+ *
+ * <h2>Key Components</h2>
+ * <ul>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting.ItemSorter} - Main sorting utility that handles
+ *       stack merging, sorting, and empty slot padding</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting.SortMethod} - Enum defining available sort methods
+ *       (alphabetical, category, quantity, mod ID)</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting.SortOrder} - Enum defining sort directions
+ *       (ascending, descending)</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.sorting.SortPreference} - Immutable record holding a
+ *       player's current sort method and order preferences</li>
+ * </ul>
+ *
+ * <h2>Sorting Pipeline</h2>
+ * <ol>
+ *   <li>Condense partial stacks into full stacks where possible</li>
+ *   <li>Filter out empty slots</li>
+ *   <li>Sort non-empty items using the appropriate comparator</li>
+ *   <li>Reverse if descending order is selected</li>
+ *   <li>Pad with empty stacks to preserve original slot count</li>
+ * </ol>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.sorting.ItemSorter
+ * @see xyz.bannach.betterinventorysorter.sorting.comparator
+ */
+package xyz.bannach.betterinventorysorter.sorting;

--- a/src/main/java/xyz/bannach/betterinventorysorter/test/CommandGameTests.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/test/CommandGameTests.java
@@ -23,13 +23,39 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Tests for the /bis command functionality.
- * These tests verify the sorting logic used by commands against player inventory regions.
+ * Game tests for the /bis command functionality.
+ *
+ * <p>This class contains NeoForge GameTest framework tests that verify the
+ * command system works correctly. Tests simulate command execution by directly
+ * calling the sorting logic that commands use.</p>
+ *
+ * <h2>Test Categories</h2>
+ * <ul>
+ *   <li>sortinv command tests - Verify main, hotbar, and all regions</li>
+ *   <li>change command tests - Verify preference updates</li>
+ *   <li>reset command tests - Verify default restoration</li>
+ *   <li>Argument parsing tests - Verify method and order validation</li>
+ * </ul>
+ *
+ * <h2>Running Tests</h2>
+ * <pre>{@code ./gradlew.bat runGameTestServer}</pre>
+ *
+ * @since 1.0.0
+ * @see xyz.bannach.betterinventorysorter.commands.ModCommands
  */
 @GameTestHolder("betterinventorysorter")
 @PrefixGameTestTemplate(false)
 public class CommandGameTests {
 
+    /**
+     * Private constructor to prevent instantiation of this test class.
+     */
+    private CommandGameTests() {}
+
+    /**
+     * Tests sorting main inventory via command.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void command_sortinv_main_sorts_main_inventory(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -59,6 +85,10 @@ public class CommandGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests sorting hotbar via command.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void command_sortinv_hotbar_sorts_hotbar(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -88,6 +118,10 @@ public class CommandGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests sorting both inventory regions via command.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void command_sortinv_all_sorts_both_regions(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -128,6 +162,10 @@ public class CommandGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that the change command updates player preferences.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void command_change_updates_player_preference(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -154,6 +192,10 @@ public class CommandGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that the reset command restores default preferences.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void command_reset_restores_defaults(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -179,6 +221,10 @@ public class CommandGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that command sorting respects player preferences.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void command_sorting_uses_player_preference(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -212,6 +258,10 @@ public class CommandGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that invalid sort method names are rejected.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void command_invalid_method_is_rejected(GameTestHelper helper) {
         // Test that invalid method parsing returns null
@@ -227,6 +277,10 @@ public class CommandGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that invalid sort order names are rejected.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void command_invalid_order_is_rejected(GameTestHelper helper) {
         // Test that invalid order parsing returns null
@@ -240,7 +294,16 @@ public class CommandGameTests {
         helper.succeed();
     }
 
-    // Helper method to sort a player region (simulates what the command does)
+    /**
+     * Helper method to sort a player's inventory region.
+     *
+     * <p>This method simulates what the /bis sortinv command does: extracts items
+     * from the target slots, sorts them, and writes them back.</p>
+     *
+     * @param player the player whose inventory to sort
+     * @param region the region to sort
+     * @param preference the sort preferences to use
+     */
     private static void sortPlayerRegion(Player player, int region, SortPreference preference) {
         InventoryMenu menu = player.inventoryMenu;
         List<Slot> targetSlots = SortHandler.getTargetSlots(menu, region);
@@ -261,7 +324,14 @@ public class CommandGameTests {
         }
     }
 
-    // Helper methods to test parsing logic (mirrors ModCommands parsing)
+    /**
+     * Helper method to parse a sort method from its name.
+     *
+     * <p>Mirrors the parsing logic in ModCommands for testing purposes.</p>
+     *
+     * @param name the serialized name to parse
+     * @return the matching SortMethod, or null if not found
+     */
     private static SortMethod parseMethod(String name) {
         for (SortMethod method : SortMethod.values()) {
             if (method.getSerializedName().equalsIgnoreCase(name)) {
@@ -271,6 +341,14 @@ public class CommandGameTests {
         return null;
     }
 
+    /**
+     * Helper method to parse a sort order from its name.
+     *
+     * <p>Mirrors the parsing logic in ModCommands for testing purposes.</p>
+     *
+     * @param name the serialized name to parse
+     * @return the matching SortOrder, or null if not found
+     */
     private static SortOrder parseOrder(String name) {
         for (SortOrder order : SortOrder.values()) {
             if (order.getSerializedName().equalsIgnoreCase(name)) {

--- a/src/main/java/xyz/bannach/betterinventorysorter/test/EdgeCaseGameTests.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/test/EdgeCaseGameTests.java
@@ -23,10 +23,41 @@ import xyz.bannach.betterinventorysorter.sorting.SortPreference;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Game tests for edge cases and special scenarios.
+ *
+ * <p>This class contains NeoForge GameTest framework tests that verify the mod
+ * handles edge cases correctly. Tests cover empty inventories, special containers,
+ * player state validation, and boundary conditions.</p>
+ *
+ * <h2>Test Categories</h2>
+ * <ul>
+ *   <li>Empty inventory tests - Verify sorting handles empty slots gracefully</li>
+ *   <li>Special container tests - Verify crafting tables and furnaces are handled</li>
+ *   <li>Player state tests - Verify spectator mode and closed containers</li>
+ *   <li>Region isolation tests - Verify sorting one region doesn't affect others</li>
+ * </ul>
+ *
+ * <h2>Running Tests</h2>
+ * <pre>{@code ./gradlew.bat runGameTestServer}</pre>
+ *
+ * @since 1.0.0
+ * @see ItemSorter
+ * @see SortHandler
+ */
 @GameTestHolder("betterinventorysorter")
 @PrefixGameTestTemplate(false)
 public class EdgeCaseGameTests {
 
+    /**
+     * Private constructor to prevent instantiation of this test class.
+     */
+    private EdgeCaseGameTests() {}
+
+    /**
+     * Tests sorting an empty container.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void empty_container_sort_is_noop(GameTestHelper helper) {
         // Sorting 27 empty slots should return 27 empty slots with no crash
@@ -45,6 +76,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests sorting a single item among empty slots.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void single_item_sort_works(GameTestHelper helper) {
         // Single item among empties should sort to index 0
@@ -66,6 +101,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that full stacks are not merged with other items.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void max_stack_items_unchanged_by_merge(GameTestHelper helper) {
         // Two full stacks of 64 stone + 64 dirt should stay as separate stacks
@@ -90,6 +129,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that many partial stacks condense to multiple full stacks.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void large_partial_stacks_condense_correctly(GameTestHelper helper) {
         // 10 stacks of 10 stone -> should condense to 1x64 + 1x36
@@ -113,6 +156,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests sorting many identical items doesn't crash.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void all_identical_items_sort_without_crash(GameTestHelper helper) {
         // 5 x 32 stone = 160 total -> condenses to 64+64+32, padded to 5 slots
@@ -141,6 +188,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that hotbar is unchanged when sorting main inventory.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void hotbar_unchanged_when_sorting_main_inventory(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -185,6 +236,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests spectator mode detection for guarding sort requests.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void spectator_mode_player_is_detected(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SPECTATOR);
@@ -194,6 +249,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests detection of closed container state.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void closed_container_returns_empty_slots(GameTestHelper helper) {
         // When no container is open, containerMenu == inventoryMenu
@@ -216,6 +275,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that crafting table slots are rejected for sorting.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void crafting_table_container_slots_rejected(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -228,6 +291,10 @@ public class EdgeCaseGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that furnace slots are rejected for sorting.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void furnace_container_slots_rejected(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);

--- a/src/main/java/xyz/bannach/betterinventorysorter/test/PreferenceGameTests.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/test/PreferenceGameTests.java
@@ -22,10 +22,40 @@ import xyz.bannach.betterinventorysorter.sorting.SortPreference;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Game tests for the player preference system.
+ *
+ * <p>This class contains NeoForge GameTest framework tests that verify the
+ * {@link SortPreference} and {@link ModAttachments#SORT_PREFERENCE} functionality.
+ * Tests cover default values, persistence, preference cycling, and integration with sorting.</p>
+ *
+ * <h2>Test Categories</h2>
+ * <ul>
+ *   <li>Attachment tests - Verify preferences are stored and retrieved correctly</li>
+ *   <li>Cycling tests - Verify method and order cycling behavior</li>
+ *   <li>Integration tests - Verify sorting uses player preferences</li>
+ * </ul>
+ *
+ * <h2>Running Tests</h2>
+ * <pre>{@code ./gradlew.bat runGameTestServer}</pre>
+ *
+ * @since 1.0.0
+ * @see SortPreference
+ * @see ModAttachments
+ */
 @GameTestHolder("betterinventorysorter")
 @PrefixGameTestTemplate(false)
 public class PreferenceGameTests {
 
+    /**
+     * Private constructor to prevent instantiation of this test class.
+     */
+    private PreferenceGameTests() {}
+
+    /**
+     * Tests that default preference attachment is set correctly.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void preference_attachment_defaults_correctly(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -37,6 +67,10 @@ public class PreferenceGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that preferences persist when set on a player.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void preference_attachment_persists_on_player(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -53,6 +87,10 @@ public class PreferenceGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that sorting uses the player's preference settings.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void sort_uses_player_preference(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -102,6 +140,10 @@ public class PreferenceGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that cycling method advances through all options.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void cycle_method_advances_to_next(GameTestHelper helper) {
         // ALPHABETICAL -> CATEGORY -> QUANTITY -> MOD_ID -> ALPHABETICAL
@@ -126,6 +168,10 @@ public class PreferenceGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that toggling order flips between ascending and descending.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void toggle_order_flips_direction(GameTestHelper helper) {
         SortPreference pref = new SortPreference(SortMethod.ALPHABETICAL, SortOrder.ASCENDING);

--- a/src/main/java/xyz/bannach/betterinventorysorter/test/SortingGameTests.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/test/SortingGameTests.java
@@ -24,10 +24,40 @@ import xyz.bannach.betterinventorysorter.sorting.SortPreference;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Game tests for core sorting functionality.
+ *
+ * <p>This class contains NeoForge GameTest framework tests that verify the
+ * {@link ItemSorter} and {@link SortHandler} classes work correctly. Tests cover
+ * all sort methods, stack merging, empty slot handling, and menu slot partitioning.</p>
+ *
+ * <h2>Test Categories</h2>
+ * <ul>
+ *   <li>Sort method tests - Verify each comparator sorts correctly</li>
+ *   <li>Stack merging tests - Verify partial stacks are combined properly</li>
+ *   <li>Sort handler tests - Verify menu slot detection and sorting</li>
+ * </ul>
+ *
+ * <h2>Running Tests</h2>
+ * <pre>{@code ./gradlew.bat runGameTestServer}</pre>
+ *
+ * @since 1.0.0
+ * @see ItemSorter
+ * @see SortHandler
+ */
 @GameTestHolder("betterinventorysorter")
 @PrefixGameTestTemplate(false)
 public class SortingGameTests {
 
+    /**
+     * Private constructor to prevent instantiation of this test class.
+     */
+    private SortingGameTests() {}
+
+    /**
+     * Tests alphabetical sorting by item name.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void alphabetical_sort_orders_by_name(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -45,6 +75,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests category sorting groups items by creative tab.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void category_sort_groups_by_tab(GameTestHelper helper) {
         // Items from different creative tabs should be grouped
@@ -65,6 +99,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests quantity sorting orders by stack count.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void quantity_sort_orders_by_count(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -82,6 +120,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests quantity sorting uses alphabetical tiebreaker.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void quantity_sort_tiebreaks_alphabetically(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -99,6 +141,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests mod ID sorting groups items by namespace.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void mod_id_sort_groups_by_namespace(GameTestHelper helper) {
         // All vanilla items share "minecraft" namespace, so they should sort alphabetically
@@ -118,6 +164,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that partial stacks are combined during merging.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void merge_stacks_combines_partial_stacks(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -133,6 +183,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that overflow items create new stacks during merging.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void merge_stacks_overflows_to_new_stack(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -155,6 +209,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that unstackable items are not merged.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void merge_stacks_does_not_merge_unstackable(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -168,6 +226,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that items with different components are not merged.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void merge_stacks_does_not_merge_different_components(GameTestHelper helper) {
         ItemStack plain = new ItemStack(Items.DIAMOND_SWORD);
@@ -187,6 +249,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that descending order reverses the sort result.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void descending_order_reverses_sort(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -204,6 +270,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that empty slots are moved to the end after sorting.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void empty_slots_moved_to_end(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -226,6 +296,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests the full pipeline: condense stacks, then sort.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void sort_pipeline_condenses_then_sorts(GameTestHelper helper) {
         List<ItemStack> stacks = new ArrayList<>();
@@ -248,6 +322,14 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Asserts that an item at the given index matches the expected item type.
+     *
+     * @param helper the test helper for assertions
+     * @param stacks the list of item stacks to check
+     * @param index the index to check
+     * @param expected the expected item type
+     */
     private static void assertItem(GameTestHelper helper, List<ItemStack> stacks, int index, net.minecraft.world.item.Item expected) {
         helper.assertTrue(
                 stacks.get(index).is(expected),
@@ -257,6 +339,10 @@ public class SortingGameTests {
 
     // ===== SortHandler Tests =====
 
+    /**
+     * Tests that chest slots are correctly partitioned.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void sort_handler_partitions_chest_slots(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -289,6 +375,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that chest contents are sorted correctly.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void sort_handler_sorts_chest_contents(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -334,6 +424,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that player main inventory slots are correctly partitioned.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void sort_handler_partitions_player_main_inventory(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -359,6 +453,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that player hotbar slots are correctly partitioned.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void sort_handler_partitions_player_hotbar(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -384,6 +482,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that invalid region codes return no slots.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void sort_handler_empty_region_returns_no_slots(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);
@@ -416,6 +518,10 @@ public class SortingGameTests {
         helper.succeed();
     }
 
+    /**
+     * Tests that sorting chest does not affect player inventory.
+     * @param helper the game test helper
+     */
     @GameTest(template = "empty")
     public static void sort_handler_does_not_affect_player_inventory_when_sorting_chest(GameTestHelper helper) {
         Player player = helper.makeMockPlayer(GameType.SURVIVAL);

--- a/src/main/java/xyz/bannach/betterinventorysorter/test/package-info.java
+++ b/src/main/java/xyz/bannach/betterinventorysorter/test/package-info.java
@@ -1,0 +1,32 @@
+/**
+ * NeoForge GameTest framework tests for the Better Inventory Sorter mod.
+ *
+ * <p>This package contains automated game tests that verify the mod's functionality
+ * using NeoForge's GameTest framework. Tests run in a real Minecraft environment
+ * and can interact with blocks, entities, and inventories.</p>
+ *
+ * <h2>Test Classes</h2>
+ * <ul>
+ *   <li>{@link xyz.bannach.betterinventorysorter.test.SortingGameTests} - Tests for core sorting
+ *       functionality, stack merging, and comparators</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.test.PreferenceGameTests} - Tests for player
+ *       preference attachments and preference cycling</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.test.EdgeCaseGameTests} - Tests for edge cases
+ *       like empty inventories, special slots, and restricted containers</li>
+ *   <li>{@link xyz.bannach.betterinventorysorter.test.CommandGameTests} - Tests for slash command
+ *       functionality and argument parsing</li>
+ * </ul>
+ *
+ * <h2>Running Tests</h2>
+ * <p>Tests are executed using the Gradle task:</p>
+ * <pre>{@code ./gradlew.bat runGameTestServer}</pre>
+ *
+ * <h2>Test Structure</h2>
+ * <p>All test classes use {@link net.neoforged.neoforge.gametest.GameTestHolder} with the
+ * mod namespace "betterinventorysorter" and {@link net.neoforged.neoforge.gametest.PrefixGameTestTemplate}
+ * set to false. Tests use the "empty" template structure.</p>
+ *
+ * @since 1.0.0
+ * @see net.minecraft.gametest.framework.GameTest
+ */
+package xyz.bannach.betterinventorysorter.test;


### PR DESCRIPTION
## Summary
- Add Javadoc documentation to all 30 Java source files
- Create 8 package-info.java files for package-level documentation
- Document all classes, methods, fields, and enum constants following standard Javadoc conventions

## Changes
- **Root package**: Betterinventorysorter, Config, ModAttachments
- **Sorting package**: ItemSorter, SortMethod, SortOrder, SortPreference
- **Comparators**: AlphabeticalComparator, CategoryComparator, ModIdComparator, QuantityComparator
- **Network package**: ModPayloads, SortRequestPayload, SyncPreferencePayload, CyclePreferencePayload
- **Server package**: SortHandler, PreferenceHandler, ServerEvents
- **Client package**: ClientEvents, ClientModBusEvents, ClientPreferenceCache, SortFeedback, SortKeyHandler, ScreenButtonInjector, SortButton
- **Commands package**: ModCommands
- **Test package**: SortingGameTests, PreferenceGameTests, EdgeCaseGameTests, CommandGameTests

## Test plan
- [x] `./gradlew.bat javadoc` completes with no warnings or errors
- [x] `./gradlew.bat build` completes successfully
- [ ] Generated documentation viewable in `build/docs/javadoc/`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)