### PR TITLE
fix: include MC version in JAR filename

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'net.neoforged.moddev' version '2.0.140'
 }
 
-version = mod_version
+version = "${mod_version}+mc${minecraft_version}"
 group = mod_group_id
 
 repositories {


### PR DESCRIPTION
## Summary

- Update JAR version to include Minecraft version suffix
- Changes filename from `bnnch_sort-0.1.0.jar` to `bnnch_sort-0.1.0+mc1.21.1.jar`

## Changes

Updated `build.gradle` version from:
```groovy
version = mod_version
```

To:
```groovy
version = "${mod_version}+mc${minecraft_version}"
```

## Test plan

- [ ] CI builds successfully
- [ ] JAR filename includes `+mc1.21.1` suffix
- [ ] Release workflow creates release with correctly named JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)